### PR TITLE
Add AI-assistant knowledge base and refresh README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 mkmf.log
 config/miners.yml
 ._*
+
+!docs/*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,270 @@
+# AGENTS.md — `cgminer_api_client`
+
+Consolidated context for AI coding assistants. For end-user docs, see [`README.md`](README.md). For the release-by-release history and the 0.2.x → 0.3.0 migration guide, see [`CHANGELOG.md`](CHANGELOG.md). For deep dives on any topic below, see [`docs/`](docs/) (start with [`docs/index.md`](docs/index.md)).
+
+## Table of contents
+
+- [What this gem is](#what-this-gem-is)
+- [Repo layout](#repo-layout) *(which files are shipped, which aren't)*
+- [How the pieces fit together](#how-the-pieces-fit-together) *(one diagram + key facts)*
+- [Conventions that matter when editing code](#conventions-that-matter-when-editing-code)
+- [Running tests and lint](#running-tests-and-lint)
+- [Adding a new cgminer command wrapper](#adding-a-new-cgminer-command-wrapper)
+- [Ruby version support](#ruby-version-support)
+- [Gotchas worth knowing up front](#gotchas-worth-knowing-up-front)
+- [Release process](#release-process)
+- [Where to look for deeper context](#where-to-look-for-deeper-context)
+
+---
+
+## What this gem is
+
+<!-- metadata: overview, stack, purpose -->
+
+A pure-Ruby client for the [cgminer](https://github.com/ckolivas/cgminer) JSON-over-TCP API. It ships as both a library and a CLI (`bin/cgminer_api_client`). Pool mode — fanning out a single command across many miners in parallel and aggregating per-miner results — is a first-class feature.
+
+**Stack:** Ruby 3.2+ only. Zero runtime dependencies beyond Ruby stdlib (`json`, `socket`, `yaml`, `pp`). Dev deps are `rspec`, `rubocop` (+ `-rake` and `-rspec`), `rake`, `simplecov`.
+
+**Footprint:** ~650 SLOC in `lib/`, ~1500 SLOC in `spec/`. Small, deliberately simple.
+
+## Repo layout
+
+<!-- metadata: directory-structure, file-organization -->
+
+```
+├── bin/cgminer_api_client        # CLI (packaged in gem)
+├── lib/cgminer_api_client.rb     # Entry point + module-level config (packaged)
+├── lib/cgminer_api_client/
+│   ├── errors.rb                 # Error < StandardError, ConnectionError, TimeoutError, ApiError
+│   ├── miner.rb                  # Single-host client
+│   ├── miner/commands.rb         # ReadOnly + Privileged.{Asc,Pga,Pool,System}
+│   ├── miner_pool.rb             # Parallel fan-out across a pool
+│   ├── miner_result.rb           # Immutable per-miner outcome (Data.define)
+│   ├── pool_result.rb            # Enumerable wrapper around Array<MinerResult>
+│   ├── socket_with_timeout.rb    # Non-blocking TCP connect with timeout
+│   └── version.rb
+├── spec/                         # RSpec unit + integration (NOT packaged)
+│   ├── cgminer_api_client/       # Unit specs, one per lib file
+│   ├── integration/              # cli_spec.rb spawns the real binary; miner_integration_spec hits a FakeCgminer
+│   └── support/                  # FakeCgminer TCP server + canned fixture responses
+├── script/fake_cgminer           # Manual sandbox; runs FakeCgminer in foreground (NOT packaged)
+├── config/miners.yml.example     # Packaged; users copy to config/miners.yml
+├── docs/                 # Generated docs for AI/human deep dives (version-controlled)
+├── .github/workflows/ci.yml      # Ubuntu matrix: Ruby 3.2 / 3.3 / 3.4 / 4.0 / head
+├── .rubocop.yml                  # TargetRubyVersion 3.2; most Metrics/* cops off
+├── .rspec                        # --color --warnings --require spec_helper
+├── .ruby-version                 # 4.0.2 (local dev only; gem supports 3.2+)
+├── Rakefile                      # default: [spec, rubocop]
+├── cgminer_api_client.gemspec
+├── CHANGELOG.md                  # Keep-a-Changelog; 0.3.0 migration guide included
+├── README.md
+└── LICENSE.txt                   # MIT
+```
+
+**What's packaged in the gem** is controlled by the `spec.files` glob in the gemspec: `lib/**/*.rb`, `bin/*`, `config/*.example`, `README.md`, `LICENSE.txt`, `CHANGELOG.md`, `cgminer_api_client.gemspec`. Everything else (specs, scripts, CI workflows, `docs/`) is dev-only.
+
+## How the pieces fit together
+
+<!-- metadata: architecture, dataflow -->
+
+```
+CLI ─┐
+     │
+Lib ─┼──> MinerPool ──(parallel threads)──> Miner ──> socket ──> cgminer
+     │       │                                │
+     │       └──returns──> PoolResult         └──raises── ConnectionError | ApiError
+     │                        │
+     └──> Miner <──────────── └──contains──> MinerResult (success|failure, immutable)
+```
+
+**Key structural facts:**
+
+1. **`Miner` and `MinerPool` both `include Miner::Commands`.** Same command surface, different execution shape. A method like `summary` runs against one miner on `Miner`, and against every miner in parallel on `MinerPool`.
+2. **`method_missing`** on both classes forwards unknown names to `query(name, *args)`. Any cgminer API command not explicitly wrapped still works. `respond_to_missing?` on both excludes `to_*`/`_*` names so implicit-conversion probes don't get forwarded as real commands.
+3. **`MinerPool#query` always returns a `PoolResult`** — an Enumerable of per-miner `MinerResult` instances in pool order. Successes and failures are both captured structurally; `MinerPool#query` never raises on a single-miner failure.
+4. **`Miner#query` raises on failure:** `ConnectionError` for transport-level problems, `ApiError` for cgminer `STATUS=E`/`F` responses. `TimeoutError < ConnectionError` for connect timeouts specifically.
+5. **Library code never writes to stderr.** The CLI owns that channel. `Miner#check_status` does `puts` on cgminer `STATUS=I`/`W` to stdout, which is by design (cgminer advisory messages).
+
+## Conventions that matter when editing code
+
+<!-- metadata: coding-style, conventions, best-practices -->
+
+### Ruby style
+
+- **Every file starts with `# frozen_string_literal: true`.** New files must too.
+- **Explicit `StandardError` in bare rescues.** `rescue StandardError => e`, not `rescue => e`. The one exception is `rescue StandardError` with no variable when you're specifically swallowing per-connection errors in `FakeCgminer` (documented in that file).
+- **`String#match?` when you only need a boolean**, not `String#match` + truthy-test. `length == 0` → `empty?`. `'%04x' % x` → `format('%04x', x)`.
+- **`YAML.safe_load_file`** for config loading — never `YAML.load_file`.
+- **`socket.wait_writable(timeout)`**, not `IO.select(nil, [s], nil, timeout)`. Required for Fiber-scheduler compatibility.
+- **`Data.define` for immutable value objects**, not `Struct` or custom classes. See `MinerResult`.
+
+### RuboCop
+
+- `.rubocop.yml` disables most `Metrics/*` cops (they fight the existing structure without adding value at this scale) and most `RSpec/*` style cops (existing suite uses idiomatic-for-its-time patterns). Correctness cops like `RSpec/RepeatedExample`, `RSpec/IdenticalEqualityAssertion`, `RSpec/LeakyConstantDeclaration` are **intentionally left on** — don't disable without a specific reason.
+- `bundle exec rubocop -A` is fine as a starting point; `bundle exec rake` (which also runs specs) is the canonical check.
+
+### Commit style
+
+- **One commit per logical step.** For multi-step changes, land each step as a separate commit. Run `bundle exec rake` (specs + rubocop) before each commit.
+- Use imperative mood ("Add X", "Fix Y"), kept brief. Look at recent `git log` for style.
+
+### Error handling
+
+- New errors should subclass one of the existing four (`Error`, `ConnectionError`, `TimeoutError`, `ApiError`) — don't add a sibling unless you have a real reason. The hierarchy is deliberate: `ConnectionError` = "couldn't reach the miner", `ApiError` = "miner answered and rejected". Keep those semantics intact.
+- Rescue narrowly. `rescue SocketError, SystemCallError, CgminerApiClient::TimeoutError` in `Miner#available?` is the pattern — bugs like `ArgumentError` should propagate, not be silently swallowed.
+- `MinerPool#query` worker threads use `rescue StandardError => e` deliberately — they capture everything into a `MinerResult.failure`. One bad miner must not take down the whole pool query.
+
+### Testing
+
+- **Unit specs live at `spec/cgminer_api_client/**`**, one file per `lib/` file. Integration specs at `spec/integration/`.
+- **Integration tests use `FakeCgminer`** — a tiny in-process TCP server (`spec/support/fake_cgminer.rb`). `FakeCgminer.with { |port| ... }` brackets a block with start/stop.
+- **CLI integration (`spec/integration/cli_spec.rb`) spawns the real binary** via `Open3.capture3`. Don't mock the CLI; fork it and assert on exit codes, stdout, stderr.
+- **Prefer fixture-based specs to mocks** for the request/parse path. `spec/support/cgminer_fixtures.rb` has canned cgminer wire-format responses grounded in cgminer's actual `codes[]` table.
+- **Test against real outputs**, not mock idealizations. Ruby 3.4 changed `pp` output for symbol-keyed hashes — don't assert on punctuation (`:k=>v` vs `k: v`); assert on semantic shape.
+- **Warnings are deliberately on** (`.rspec: --warnings`). Keep the suite warning-clean.
+- `config.order = :random` — specs must be order-independent.
+- `mocks.verify_partial_doubles = true` — doubles must match real method signatures.
+
+### Adding tests for a new command
+
+Mirror the pattern in `spec/cgminer_api_client/miner/commands_spec.rb`. For a new read-only command:
+
+```ruby
+describe '#your_new_command' do
+  it 'calls query(:your_new_command)' do
+    expect(miner).to receive(:query).with(:your_new_command)
+    miner.your_new_command
+  end
+end
+```
+
+For integration, add a fixture to `spec/support/cgminer_fixtures.rb` (grounded in real cgminer wire format if possible) and exercise via `FakeCgminer` in `spec/integration/miner_integration_spec.rb`.
+
+## Running tests and lint
+
+<!-- metadata: testing, local-dev, commands -->
+
+```sh
+bundle install
+bundle exec rake                         # spec + rubocop (default task)
+bundle exec rspec                        # all specs
+bundle exec rspec spec/cgminer_api_client  # unit only
+bundle exec rspec spec/integration         # integration only
+bundle exec rspec path/to/spec.rb:123      # single example by line
+bundle exec rubocop                      # lint only
+bundle exec rubocop -A                   # lint + auto-correct (review diffs!)
+```
+
+**Coverage** is always on (SimpleCov in `spec_helper.rb`). Reports land in `coverage/` — don't commit that directory (it's `.gitignore`d).
+
+**Manual sandbox** for exercising the CLI without real miners:
+
+```sh
+# terminal 1
+./script/fake_cgminer              # listens on 127.0.0.1:4028
+# terminal 2
+cp config/miners.yml.example config/miners.yml
+bundle exec bin/cgminer_api_client summary
+```
+
+## Adding a new cgminer command wrapper
+
+<!-- metadata: extending, how-to -->
+
+1. **Decide read-only or privileged.** Privileged commands need the miner's `allow` setting to include a `W:` (write) prefix for your IP; read-only commands don't.
+2. **Pick the right sub-module** in `lib/cgminer_api_client/miner/commands.rb`:
+   - Read-only → `ReadOnly`
+   - Privileged ASC/PGA device op → `Privileged::Asc` or `Privileged::Pga`
+   - Pool management → `Privileged::Pool`
+   - Host-level → `Privileged::System`
+3. **Write the wrapper as a one-liner.** Pattern for read-only:
+   ```ruby
+   def your_command(arg)
+     query(:your_command, arg)
+   end
+   ```
+   Pattern for privileged:
+   ```ruby
+   def your_command(arg)
+     query(:your_command, arg) unless access_denied?
+   end
+   ```
+   If the response is a single-element array that callers will want unwrapped, do `query(:your_command)[0]` — **but** if you add another such command, also override it in `MinerPool` so it works correctly on a pool (see the existing override block for `summary`/`coin`/`config`/`version` in `miner_pool.rb`). Without that override, pool calls will silently return only the first miner's response.
+4. **Add specs** in `spec/cgminer_api_client/miner/commands_spec.rb`. If the command has interesting response parsing, add a fixture and an integration test too.
+5. **Update `README.md`** — the "Commands & Arguments" section lists wrapped commands.
+6. **Don't add a `CHANGELOG.md` entry for a tiny one-liner** — batch them in the release notes.
+
+If you don't want to wrap a command explicitly, `method_missing` already handles it: `miner.anything_new('arg')` works. Wrapping is for discoverability (it shows up in `respond_to?(:method, false)` and in `Miner::Commands.instance_methods`, which the CLI validates against) and ergonomics.
+
+## Ruby version support
+
+<!-- metadata: runtime, compatibility -->
+
+- **Minimum:** Ruby 3.2. Enforced by the gemspec (`required_ruby_version >= 3.2`).
+- **CI matrix:** 3.2, 3.3, 3.4, 4.0 (all required), plus `head` (allowed to fail; early-warning signal).
+- **Local dev pin:** `.ruby-version` says 4.0.2. Only affects contributors.
+
+**When proposing Ruby code, verify every stdlib class/method you reference exists on 3.2.** A few sharp edges to be aware of:
+
+- `Data.define` requires 3.2. Older Ruby literature recommends `Struct` — don't switch.
+- `pp`'s symbol-keyed hash output changed in 3.4: `:k=>v` → `k: v`. The CLI integration specs handle both; if you add more CLI output specs, don't assert on exact punctuation.
+- Pattern matching (`case / in`) works on 3.0+; fine on 3.2.
+- `socket.wait_writable(timeout)` works on 3.0+; fine on 3.2.
+
+## Gotchas worth knowing up front
+
+<!-- metadata: caveats, surprises -->
+
+These are real past-incident-shaped corners of the codebase. The CHANGELOG has the full story; keep these in mind before "cleaning up" related code:
+
+1. **`Miner#query`'s parameter escape** uses `gsub('\\') { '\\\\' }` (block form), not `gsub('\\', '\\\\')`. The latter is a silent no-op because in gsub's replacement-string DSL, `\\` denotes a single literal backslash. There are four explicit specs locking this down — don't "simplify" back to the string form.
+
+2. **`MinerPool#summary`/`coin`/`config`/`version`/`check` are explicitly overridden** in `miner_pool.rb`. If you remove the override block, every multi-miner pool silently loses all but the first miner's response (pre-0.3.0 bug). The tests should catch this, but don't rely on it.
+
+3. **`Miner#available?` opens a fresh socket every call.** No cache. If that seems expensive, it's because a previous caching implementation permanently marked miners as unavailable after any transient blip. That's why the cache is gone.
+
+4. **`Miner#query` does NOT short-circuit on `!available?`.** As of 0.3.0, it calls `perform_request` directly and lets `ConnectionError` propagate. An earlier implementation silently returned `nil` for unreachable miners and caused real operator pain.
+
+5. **The `}{` repair in `Miner#perform_request`** is legacy defensive code that may not fire on modern cgminer. Don't remove without a repro; don't "clean up" by adding tests that pass synthetic input — add a real-cgminer repro or leave it alone. See `spec/support/cgminer_fixtures.rb` for the commentary.
+
+6. **`access_denied?` raises a bare `'access_denied'` string** (a `RuntimeError` with that message), not a `CgminerApiClient::ApiError`. It's caught by `rescue StandardError`/`RuntimeError` but **not** by `rescue CgminerApiClient::Error`. This is inconsistent with the rest of the error hierarchy — worth knowing, not worth fixing on its own.
+
+7. **`config/miners.yml` is resolved relative to process CWD**, not gem install dir. Library consumers embedding `MinerPool` need to either align CWD or construct `Miner` instances directly.
+
+8. **Out-of-band git changes are normal.** Don't treat surprising git state (uncommitted changes you didn't make, etc.) as a tool malfunction — the maintainer makes changes outside the assistant session.
+
+## Release process
+
+<!-- metadata: release, publishing -->
+
+Not automated. On a clean `master`:
+
+```sh
+bundle exec rake                                 # must pass clean
+# bump version in lib/cgminer_api_client/version.rb
+# update CHANGELOG.md (Keep-a-Changelog format, one section per release)
+git commit -am "Release vX.Y.Z"
+gem build cgminer_api_client.gemspec             # produces cgminer_api_client-X.Y.Z.gem
+gem push cgminer_api_client-X.Y.Z.gem            # requires 2FA (rubygems_mfa_required=true)
+git tag vX.Y.Z
+git push origin master vX.Y.Z
+```
+
+The `.gem` artifact shouldn't be committed to the repo, but one is present at the root (`cgminer_api_client-0.3.0.gem`) from the 0.3.0 release as an untracked file.
+
+## Where to look for deeper context
+
+<!-- metadata: doc-navigation -->
+
+| Question | File |
+|---|---|
+| How do the classes relate architecturally? Why `method_missing`? Why `Data.define`? | [`docs/architecture.md`](docs/architecture.md) |
+| What does each class do? | [`docs/components.md`](docs/components.md) |
+| What's the public method signature for X? CLI exit codes? Wire format? | [`docs/interfaces.md`](docs/interfaces.md) |
+| What's in a `MinerResult` / `PoolResult`? What errors can be raised? | [`docs/data_models.md`](docs/data_models.md) |
+| How does a request flow through the code? Parallel fan-out? CLI? | [`docs/workflows.md`](docs/workflows.md) |
+| Runtime deps? Why Ruby 3.2+? | [`docs/dependencies.md`](docs/dependencies.md) |
+| Known doc/code drift, caveats, things I'm not sure about | [`docs/review_notes.md`](docs/review_notes.md) |
+| Full knowledge-base index | [`docs/index.md`](docs/index.md) |
+| User-facing docs | [`README.md`](README.md) |
+| Release history and 0.2.x→0.3.0 migration guide | [`CHANGELOG.md`](CHANGELOG.md) |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/jramos/cgminer_api_client/actions/workflows/ci.yml/badge.svg)](https://github.com/jramos/cgminer_api_client/actions/workflows/ci.yml)
 
-A gem that allows sending API commands to a pool of [cgminer](https://github.com/ckolivas/cgminer) instances.
+A gem that allows sending API commands to a pool of [cgminer](https://github.com/ckolivas/cgminer) instances. Ships as both a Ruby library and a CLI (`cgminer_api_client <command>`). Zero runtime dependencies beyond the Ruby standard library.
 
 ## Requirements
 
@@ -131,11 +131,41 @@ distinct conditions, unlike in 0.2.x where they were conflated.
 pool.restart      # PoolResult of per-miner outcomes
 ```
 
+### Errors
+
+All gem-specific errors descend from `CgminerApiClient::Error < StandardError`:
+
+-   `CgminerApiClient::ConnectionError` — transport-level: the miner
+    was unreachable (DNS failure, connection refused, etc.).
+-   `CgminerApiClient::TimeoutError` — a `ConnectionError` subclass
+    for connect timeouts specifically.
+-   `CgminerApiClient::ApiError` — protocol-level: the miner answered
+    and returned a `STATUS=E`/`F` response.
+
+`rescue CgminerApiClient::Error` catches everything gem-specific.
+`rescue CgminerApiClient::ConnectionError` catches both generic
+transport failures and connect timeouts. A `MinerPool` query never
+raises per-miner errors — they land on the corresponding
+`MinerResult.failure` inside the returned `PoolResult`.
+
 ## CLI Usage
 
 API commands can be sent to your miner pool from the command line.
 
     $ cgminer_api_client <command> (<arguments>)
+
+### Exit Codes and Streams
+
+-   exit `0` — at least one miner's command succeeded.
+-   exit `1` — every miner failed, or a top-level exception bubbled up.
+-   exit `64` — unknown command or missing command argument (`EX_USAGE`).
+
+Per-miner responses are printed to stdout with a `host:port:` header.
+Per-miner errors are printed to stderr as
+`host:port: ErrorClass: message`. Set `DEBUG=1` to also print full
+backtraces for any top-level exception:
+
+    $ DEBUG=1 cgminer_api_client summary
 
 ### Commands & Arguments
 
@@ -200,6 +230,13 @@ The following privileged miner and pool commands are currently available:
 -   zero(which = 'All', full_summary = false)
 
 Any cgminer API commands not explictly defined above are implemented using `method_missing`. A complete list of available API commands and options can be found in the [cgminer API-README](https://github.com/ckolivas/cgminer/blob/master/API-README).
+
+## Further Reading
+
+-   [`CHANGELOG.md`](CHANGELOG.md) — release history and the 0.2.x → 0.3.0 migration guide.
+-   [`AGENTS.md`](AGENTS.md) — context for AI coding assistants; also a useful conventions-and-extension guide for human contributors.
+-   [`docs/`](docs/) — topic-split deep dives on architecture, components, interfaces, data models, workflows, and dependencies. Start with [`docs/index.md`](docs/index.md).
+-   [cgminer API-README](https://github.com/ckolivas/cgminer/blob/master/API-README) — upstream documentation for the JSON API surface this gem wraps.
 
 ## Contributing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,183 @@
+# Architecture
+
+## Design goals
+
+1. **One command surface, two execution shapes.** A single module (`Miner::Commands`) defines every cgminer command. `Miner` runs it against one host; `MinerPool` runs it against many in parallel. Consumers learn the command set once.
+2. **Structural success/failure reporting.** Pool queries never silently drop failures or raise on the first one. Every miner gets a `MinerResult` and the caller decides what to do with failures.
+3. **Zero runtime dependencies.** Only Ruby stdlib (`json`, `socket`, `yaml`).
+4. **Transport-level vs protocol-level errors are distinct.** `ConnectionError` (couldn't reach the miner) is a different class from `ApiError` (miner answered and rejected). This matters operationally — a network blip shouldn't look like an auth denial.
+5. **Library code never writes to stdout/stderr.** The CLI renders results; the library carries them.
+
+## Design patterns
+
+### Mixin-driven command surface
+
+`Miner::Commands` is a module that includes two sub-modules: `ReadOnly` and `Privileged`. `Privileged` itself re-includes four namespaced sub-modules (`Asc`, `Pga`, `Pool`, `System`). Both `Miner` and `MinerPool` mix in `Miner::Commands`, so they share the exact same surface.
+
+```mermaid
+classDiagram
+    class Miner_Commands_ReadOnly {
+        +summary()
+        +stats()
+        +pools()
+        +devs()
+        +version()
+        +...()
+    }
+    class Miner_Commands_Privileged_Asc {
+        +ascenable(n)
+        +ascset(n, opt, val)
+        +...()
+    }
+    class Miner_Commands_Privileged_Pool {
+        +addpool(url, user, pass)
+        +switchpool(n)
+        +...()
+    }
+    class Miner_Commands_Privileged_System {
+        +restart()
+        +quit()
+        +save(filename)
+        +...()
+    }
+    class Miner_Commands {
+        <<module>>
+    }
+    Miner_Commands_ReadOnly --|> Miner_Commands
+    Miner_Commands_Privileged_Asc --|> Miner_Commands
+    Miner_Commands_Privileged_Pool --|> Miner_Commands
+    Miner_Commands_Privileged_System --|> Miner_Commands
+    Miner --|> Miner_Commands
+    MinerPool --|> Miner_Commands
+```
+
+The Commands module calls `query(:foo)` on its including class. `Miner#query` hits the miner directly; `MinerPool#query` fans out across every miner in parallel and returns a `PoolResult`. So a single convenience method like `summary` works transparently in both contexts.
+
+### `method_missing` fallback for uncommon cgminer commands
+
+Both `Miner` and `MinerPool` define `method_missing(name, *) { query(name, *) }` so any cgminer API command not explicitly wrapped by `Miner::Commands` can still be called by name:
+
+```ruby
+pool.some_new_command('arg1', 'arg2')  # → pool.query(:some_new_command, 'arg1', 'arg2')
+```
+
+Both also implement `respond_to_missing?` so `respond_to?` and `Object#method` reflect this. The intentional carve-out: names starting with `to_` or `_` are rejected so implicit-conversion probes (`to_ary`, `to_str`, `to_hash`, `_dump`, etc.) and internal probes don't get forwarded to cgminer as real commands.
+
+### Immutable value objects via `Data.define`
+
+`MinerResult` uses Ruby 3.2+'s `Data.define` to get immutability, value-based equality, hashability, pattern-match support (`deconstruct_keys`), and a decent `inspect` for free. The class adds only domain helpers (`.success`, `.failure`, `#ok?`, `#failed?`, `#raise!`).
+
+This is deliberately not a custom `Result`/`Either` hierarchy with success/failure subclasses — `Data.define` with two factories and an `ok?` predicate carries enough weight and costs nothing to define.
+
+### Enumerable result collection
+
+`PoolResult` wraps `Array<MinerResult>` and includes `Enumerable`. Callers iterate `MinerResult`s by default and reach for `.values` / `.errors` / predicate helpers for common projections. Lookup-by-key (`result[0]`, `result[miner]`, `result["host:port"]`) is provided via `#[]`.
+
+`PoolResult` is frozen at construction (`@results.freeze`), and equality delegates to the underlying results array.
+
+### Parallel fan-out with capture-everything semantics
+
+`MinerPool#query` spawns one `Thread` per miner. Each thread runs `miner.query` inside a rescue that converts **any** `StandardError` into a `MinerResult.failure`. After `join`-ing all threads, the results are wrapped in a `PoolResult` in pool order (via `threads.map(&:value)`).
+
+Consequences:
+
+- A single hostile/hung miner can't take down a pool query — other miners run concurrently and their results arrive intact.
+- Failures are captured structurally, not re-raised. The caller sees which miners succeeded and which failed, with specific exceptions attached.
+- Thread ordering is deterministic w.r.t. pool order (because the threads were created in iteration order and joined in the same order).
+
+### Dual error taxonomy
+
+```mermaid
+classDiagram
+    class StandardError
+    class Error {
+        <<CgminerApiClient::Error>>
+    }
+    class ConnectionError {
+        <<transport-level>>
+        "socket open failed, DNS lookup failed, etc"
+    }
+    class TimeoutError {
+        <<connect timeout>>
+    }
+    class ApiError {
+        <<protocol-level>>
+        "miner returned STATUS=E or STATUS=F"
+    }
+    Error --|> StandardError
+    ConnectionError --|> Error
+    TimeoutError --|> ConnectionError
+    ApiError --|> Error
+```
+
+`TimeoutError < ConnectionError` means callers that only care about "the miner is unreachable for any reason" can `rescue ConnectionError`, while callers who want to react specifically to connect timeouts (maybe log them differently) can `rescue TimeoutError`. All gem errors descend from `CgminerApiClient::Error < StandardError`, so a blanket `rescue CgminerApiClient::Error` covers everything gem-specific without catching unrelated exceptions.
+
+### Module-level config via singleton methods
+
+`lib/cgminer_api_client.rb` exposes `default_host`, `default_port`, and `default_timeout` as module-level attrs with lazy-default getters (`defined?(@x) ? @x : default`). `CgminerApiClient.config { |c| c.default_port = 4028 }` is just `yield self` — no builder class, no DSL. This keeps configuration inert when not used.
+
+## The cgminer wire protocol (what the gem actually speaks)
+
+The gem implements a narrow subset of cgminer's API — specifically, the JSON variant (not the plain-text one).
+
+**Request:**
+
+```json
+{"command":"summary","parameter":"0"}
+```
+
+Sent as a single `write` on a TCP socket. `parameter` is optional; when present it's a comma-separated string. Literal commas and backslashes inside parameter values are backslash-escaped by `Miner#query` (see `CHANGELOG.md` for the gory history of how the escape used to silently no-op).
+
+**Response:**
+
+cgminer writes a JSON object and closes the connection. Read-to-EOF is how the client knows the response is complete. Every response has a `STATUS` array whose first element carries a `STATUS` code letter:
+
+| Code | Meaning | Gem behavior |
+|------|---------|--------------|
+| `S`  | Success | silent |
+| `I`  | Info    | `puts` to stdout |
+| `W`  | Warning | `puts` to stdout |
+| `E`  | Error   | raises `ApiError` |
+| `F`  | Fatal   | raises `ApiError` |
+
+The gem also performs two small input-repair passes on the raw response bytes before `JSON.parse`:
+
+1. Bytes below 0x20 (control characters) are re-escaped as `\uXXXX`. Cgminer can emit raw control bytes in user-supplied strings (pool names, worker IDs) that break standard JSON parsers.
+2. `}{` → `}, {` and `[,{` → `[ {` substitutions are attempted on malformed multi-command responses. This is legacy defensive code; see `spec/support/cgminer_fixtures.rb` for notes on whether it still fires.
+
+After parsing, `Miner#sanitized` normalizes keys recursively: `"MHS av"` → `:mhs_av`, `"Pool Rejected%"` → `:pool_rejected%`. Callers always see snake_case symbol keys.
+
+For commands whose name contains `+` (cgminer multi-command syntax, e.g. `summary+pools`), `check_status` is called per sub-response and the full data shape is returned as-is (no single-element unwrap).
+
+## Single-miner convenience unwrap
+
+Read-only methods that cgminer returns inside a single-element array — `summary`, `coin`, `config`, `version`, `check` — unwrap that one element in `Miner::Commands::ReadOnly` via `query(:name)[0]`. On a single `Miner` this is correct. On a `MinerPool` the inherited behavior would silently drop every miner except the first, so `MinerPool` overrides these five methods to map the unwrap across every successful `MinerResult` in a `PoolResult` instead:
+
+```ruby
+# MinerPool#summary (simplified)
+unwrap_first(query(:summary))
+# where unwrap_first replaces each successful MinerResult.value
+# with value.first, passing failures through unchanged.
+```
+
+This was a pre-existing bug before 0.3.0; see `CHANGELOG.md` under "Fixed".
+
+## Config file contract
+
+`MinerPool.new` reads `config/miners.yml` relative to the process CWD using `YAML.safe_load_file`. Each entry is a hash with `host` (required), `port` (optional; falls back to `CgminerApiClient.default_port`), and `timeout` (optional). If the file doesn't exist, `MinerPool.new` raises `"Please create config/miners.yml"`.
+
+The file is resolved relative to the process's CWD, not the gem's install location — meaning CLI users run it from a directory that has `config/miners.yml`, and library consumers embedding `MinerPool` need to either keep CWD aligned or construct `Miner` instances directly.
+
+## What the CLI adds on top
+
+`bin/cgminer_api_client` is a thin driver:
+
+1. Validate that `ARGV[0]` corresponds to a known command (`Miner::Commands.instance_methods`); exit 64 (`EX_USAGE`) if not.
+2. Build a `MinerPool` and run `pool.query(command, *ARGV)`.
+3. Iterate the returned `PoolResult`:
+   - Successes: print `host:port:` header to stdout, then `pp value`.
+   - Failures: print `host:port: ErrorClass: message` to stderr.
+4. Exit 0 if any miner succeeded, 1 if all failed.
+5. `DEBUG=1` prints full backtraces for any top-level exception via `Exception#full_message(highlight: false)`.
+
+The CLI is the only place in the gem that writes to stderr.

--- a/docs/codebase_info.md
+++ b/docs/codebase_info.md
@@ -1,0 +1,111 @@
+# Codebase Info
+
+## What this is
+
+`cgminer_api_client` is a pure-Ruby client for the [cgminer](https://github.com/ckolivas/cgminer) JSON-over-TCP API. It ships as both a library (for embedding into other Ruby applications) and a CLI (`bin/cgminer_api_client`) for operator use. Pool mode — fanning out a single command across many miners in parallel and aggregating per-miner results — is a first-class feature.
+
+The gem is small (~650 SLOC in `lib/`) and single-purpose. It does not bundle a CLI framework, a logger, an HTTP library, or any other runtime dependency: everything is built on Ruby stdlib.
+
+## Stack
+
+- **Language:** Ruby 3.2+ (gemspec `required_ruby_version`). CI matrix tests 3.2, 3.3, 3.4, 4.0, and `head` (head allowed to fail). Local development is pinned to Ruby 4.0.2 via `.ruby-version`.
+- **Runtime dependencies:** none beyond stdlib (`json`, `socket`, `yaml`).
+- **Dev dependencies:** `rake`, `rspec`, `rubocop` (+ `rubocop-rspec`, `rubocop-rake`), `simplecov`.
+- **Test framework:** RSpec 3.13. Unit specs at `spec/cgminer_api_client/**`, integration specs at `spec/integration/**`.
+- **Lint:** RuboCop with `TargetRubyVersion: 3.2`. Default Rake task runs specs then rubocop.
+- **CI:** GitHub Actions (`.github/workflows/ci.yml`). Runs `bundle exec rake` on every push/PR to `master` and `develop`.
+- **Coverage:** SimpleCov; last reported at 99.66% on `lib/`.
+
+## Directory layout
+
+```
+cgminer_api_client/
+├── bin/
+│   └── cgminer_api_client        # The CLI executable (packaged with gem)
+├── lib/
+│   ├── cgminer_api_client.rb     # Entry point: requires, default_host/port/timeout, .config
+│   └── cgminer_api_client/
+│       ├── errors.rb             # Error < StandardError, ConnectionError, TimeoutError, ApiError
+│       ├── miner.rb              # Miner class: single-host client, query + perform_request
+│       ├── miner/
+│       │   └── commands.rb       # ReadOnly + Privileged (Asc, Pga, Pool, System) mixins
+│       ├── miner_pool.rb         # MinerPool: parallel fan-out across a pool of Miners
+│       ├── miner_result.rb       # Immutable MinerResult (Data.define) per-miner outcome
+│       ├── pool_result.rb        # Enumerable PoolResult wrapper around Array<MinerResult>
+│       ├── socket_with_timeout.rb# Non-blocking TCP connect with timeout
+│       └── version.rb            # VERSION = "0.3.0"
+├── spec/
+│   ├── spec_helper.rb            # SimpleCov + loads support/**/*.rb
+│   ├── cgminer_api_client_spec.rb
+│   ├── cgminer_api_client/
+│   │   ├── miner_spec.rb
+│   │   ├── miner_pool_spec.rb
+│   │   ├── miner_result_spec.rb
+│   │   ├── pool_result_spec.rb
+│   │   └── miner/commands_spec.rb
+│   ├── integration/
+│   │   ├── cli_spec.rb           # Spawns the real bin/ via Open3
+│   │   └── miner_integration_spec.rb # Full request → socket → response path
+│   └── support/
+│       ├── cgminer_fixtures.rb   # Canned cgminer wire-format JSON responses
+│       └── fake_cgminer.rb       # Tiny TCP server used by integration specs
+├── script/
+│   └── fake_cgminer              # Manual sandbox: starts FakeCgminer on a port
+├── config/
+│   └── miners.yml.example        # Ships in the gem; user copies to config/miners.yml
+├── .github/workflows/ci.yml
+├── .rubocop.yml                  # TargetRubyVersion 3.2; Metrics cops largely off
+├── .rspec                        # --color --warnings --require spec_helper
+├── .ruby-version                 # 4.0.2 (local dev only; gem supports 3.2+)
+├── Rakefile                      # default: spec + rubocop
+├── Gemfile / Gemfile.lock
+├── cgminer_api_client.gemspec
+├── CHANGELOG.md                  # Keep-a-Changelog format, 0.3.0 migration guide included
+├── README.md
+└── LICENSE.txt                   # MIT
+```
+
+Packaged-in-the-gem files are controlled by the `spec.files` glob in the gemspec: `lib/**/*.rb`, `bin/*`, `config/*.example`, README, LICENSE, CHANGELOG, and the gemspec itself. Notably, `spec/`, `script/`, and `.github/` are **not** packaged.
+
+## Languages and tooling
+
+| | |
+|---|---|
+| Primary language | Ruby |
+| Other languages | None |
+| Build tool | `bundler` (gem), `rake` (default task) |
+| Package format | RubyGem (`.gem`) |
+| Distribution | [RubyGems.org](https://rubygems.org/gems/cgminer_api_client) |
+
+## High-level module map
+
+```mermaid
+graph TB
+    CLI[bin/cgminer_api_client] --> MP[MinerPool]
+    Lib[Library consumer] --> MP
+    Lib --> M[Miner]
+    MP -->|parallel threads| M
+    MP -->|returns| PR[PoolResult]
+    PR -->|wraps| MR[MinerResult]
+    MR -->|references| M
+    M -.includes.-> Cmds[Miner::Commands<br/>ReadOnly + Privileged]
+    M -.includes.-> SWT[SocketWithTimeout]
+    MP -.includes.-> Cmds
+    M -->|raises| Err[Errors:<br/>ConnectionError / TimeoutError / ApiError]
+    SWT -->|raises| Err
+```
+
+## Key facts worth knowing up front
+
+1. **`Miner` and `MinerPool` both `include Miner::Commands`.** The same read-only/privileged command surface works on both. On `Miner`, each command hits one miner. On `MinerPool`, each command fans out to every miner in parallel.
+2. **`method_missing` on both classes** forwards unknown method names to `query(name, *args)`, so any cgminer API command not explicitly wrapped still works (`pool.some_new_command`).
+3. **`query` returns parsed Ruby** (symbol-keyed snake_case hashes). Key normalization happens in `Miner#sanitized`.
+4. **`MinerPool#query` returns a `PoolResult`** — an Enumerable of per-miner `MinerResult` instances. Failures are captured structurally (carried as `MinerResult.failure`), not thrown.
+5. **The library never writes to stderr.** Error-to-stderr is the CLI's job.
+6. **No runtime dependencies.** Stdlib only.
+
+## Version and release posture
+
+- Current release: **0.3.0** (2026-04-07). See `CHANGELOG.md` for the full release notes and 0.2.x → 0.3.0 migration guide.
+- Semantic Versioning; the 0.x prefix means breaking changes are allowed between minor versions. 0.3.0 introduced several (see Migration Guide).
+- `rubygems_mfa_required` is set in gemspec metadata.

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,182 @@
+# Components
+
+Every major component lives in a single file under `lib/cgminer_api_client/`. None of them exceed ~200 SLOC. The composition is flat; there is no ceremony layer (no service objects, no factories, no DI container).
+
+## Component map
+
+```mermaid
+graph LR
+    subgraph lib_cgminer_api_client_rb["lib/cgminer_api_client.rb"]
+        ModConfig[module-level config<br/>default_host/port/timeout + .config]
+    end
+    subgraph errors_rb["errors.rb"]
+        ErrClasses[Error hierarchy]
+    end
+    subgraph socket_with_timeout_rb["socket_with_timeout.rb"]
+        SWT[SocketWithTimeout]
+    end
+    subgraph miner_rb["miner.rb"]
+        M[Miner]
+    end
+    subgraph miner_commands_rb["miner/commands.rb"]
+        Cmds[Miner::Commands<br/>ReadOnly + Privileged.Asc/Pga/Pool/System]
+    end
+    subgraph miner_pool_rb["miner_pool.rb"]
+        MP[MinerPool]
+    end
+    subgraph miner_result_rb["miner_result.rb"]
+        MR[MinerResult]
+    end
+    subgraph pool_result_rb["pool_result.rb"]
+        PR[PoolResult]
+    end
+
+    M -.includes.-> SWT
+    M -.includes.-> Cmds
+    MP -.includes.-> Cmds
+    MP -->|owns| M
+    MP -->|returns| PR
+    PR -->|contains| MR
+    MR -->|references| M
+    M -->|raises| ErrClasses
+    SWT -->|raises| ErrClasses
+    M -->|uses defaults from| ModConfig
+```
+
+## Component list
+
+### `CgminerApiClient` (module)
+**File:** `lib/cgminer_api_client.rb`
+
+Entry point and configuration holder. Loads all other files in dependency order and exposes module-level attrs:
+
+- `default_host` (default `'127.0.0.1'`)
+- `default_port` (default `4028`)
+- `default_timeout` (default `5` seconds)
+- `.config { |c| ... }` — yields `self` if a block is given; no-op otherwise
+
+Used by `Miner#initialize` to fill in any constructor argument the caller left nil.
+
+### `CgminerApiClient::Error` and siblings
+**File:** `lib/cgminer_api_client/errors.rb`
+
+Four exception classes:
+
+- `Error < StandardError` — base class for everything gem-specific.
+- `ConnectionError < Error` — transport-level failure (can't reach the miner).
+- `TimeoutError < ConnectionError` — specifically a connect timeout.
+- `ApiError < Error` — miner answered but returned STATUS=E or STATUS=F.
+
+Raised from `Miner`, `MinerPool` (via rescue-and-capture), and `SocketWithTimeout`. See [architecture.md](architecture.md#dual-error-taxonomy).
+
+### `CgminerApiClient::SocketWithTimeout` (module)
+**File:** `lib/cgminer_api_client/socket_with_timeout.rb`
+
+A one-method mixin: `open_socket(host, port, timeout)`. Builds a non-blocking TCP socket, attempts `connect_nonblock`, and uses `socket.wait_writable(timeout)` to wait for completion with a deadline. Raises `CgminerApiClient::TimeoutError` on expiry; returns the connected socket otherwise.
+
+Handles the `Errno::EISCONN`-on-second-connect-nonblock quirk that Linux exhibits when connection completes during the wait. On macOS/BSD, the second call returns 0 cleanly and the `EISCONN` branch doesn't fire.
+
+Mixed into `Miner`. The switch from `IO.select(nil, [socket], nil, timeout)` to `socket.wait_writable(timeout)` in 0.3.0 is what makes this Fiber-scheduler compatible.
+
+### `CgminerApiClient::Miner`
+**File:** `lib/cgminer_api_client/miner.rb`
+
+Per-host client. Carries `host`, `port`, `timeout`. Public surface:
+
+- `query(method, *params)` — marshal request, send, parse, dispatch `check_status`, return sanitized data. Raises `ConnectionError` on transport failure, `ApiError` on cgminer-reported error.
+- `available?` — true reachability probe. Opens a fresh socket every call (no cache). Returns `false` on `SocketError`/`SystemCallError`/`TimeoutError`; lets other exceptions propagate. Does **not** perform an API handshake.
+- All methods from `Miner::Commands::ReadOnly` and `Miner::Commands::Privileged` via `include`.
+- `method_missing` forwards unknown names to `query`.
+- `respond_to_missing?` says yes for any name that isn't `to_*`/`_*`.
+
+Private methods: `perform_request` (socket write/read/JSON parse, plus control-byte re-escape and `}{` repair), `check_status` (STATUS code dispatch), `sanitized` (recursive key normalization).
+
+### `CgminerApiClient::Miner::Commands` (module)
+**File:** `lib/cgminer_api_client/miner/commands.rb`
+
+Command surface. Four nested modules:
+
+| Module | Scope | Notable members |
+|---|---|---|
+| `ReadOnly` | safe queries | `summary`, `stats`, `pools`, `devs`, `devdetails`, `coin`, `config`, `version`, `check(cmd)`, `notify`, `usbstats`, `privileged`, `asc(n)`, `asccount`, `pga(n)`, `pgacount` |
+| `Privileged::Asc` | per-ASC ops | `ascenable`, `ascdisable`, `ascidentify`, `ascset` |
+| `Privileged::Pga` | per-PGA ops | `pgaenable`, `pgadisable`, `pgaidentify`, `pgaset` |
+| `Privileged::Pool` | pool config | `addpool`, `removepool`, `switchpool`, `enablepool`, `disablepool`, `poolpriority`, `poolquota` |
+| `Privileged::System` | host-level | `restart`, `quit`, `save`, `setconfig`, `debug`, `failover_only`, `hotplug`, `zero` |
+
+`Commands::ReadOnly#privileged` calls `query(:privileged)` and catches `ApiError` → `false` (miner refused). All other exceptions (including `ConnectionError`) propagate so a network blip doesn't read as "access denied." The `access_denied?` gate used by every `Privileged::*` method raises `'access_denied'` when `privileged` returns false, so a single rescue point in the caller picks up auth rejections.
+
+Both `Miner` and `MinerPool` `include Miner::Commands`. The `Commands` methods only call `query(...)`; `Miner#query` and `MinerPool#query` provide the two execution shapes.
+
+### `CgminerApiClient::MinerPool`
+**File:** `lib/cgminer_api_client/miner_pool.rb`
+
+Parallel fan-out wrapper. Loads `config/miners.yml` on construction (via `load_miners!`, using `YAML.safe_load_file`) and builds one `Miner` per entry.
+
+Public surface:
+
+- `query(method, *params)` — spawns one `Thread` per miner, runs `miner.query` inside each, and captures each result as a `MinerResult.success` or `.failure`. Returns a `PoolResult` of per-miner outcomes in pool order.
+- `summary`, `coin`, `config`, `version`, `check(cmd)` — overridden to unwrap cgminer's single-element-array response on each `MinerResult.value` while preserving failures. Fixes the pre-0.3.0 bug where the inherited `ReadOnly` implementations silently dropped all but the first miner.
+- `available_miners` — parallel `Miner#available?` across all miners; returns the reachable ones.
+- `unavailable_miners` — `@miners - available_miners`.
+- `miners` / `miners=` — direct access to the underlying array.
+- `reload_miners!` — re-reads `config/miners.yml`.
+- `method_missing` / `respond_to_missing?` — same forwarding shape as `Miner`.
+
+All privileged/read-only commands from `Miner::Commands` are available here too and automatically execute in pool-parallel mode.
+
+### `CgminerApiClient::MinerResult`
+**File:** `lib/cgminer_api_client/miner_result.rb`
+
+Immutable per-miner outcome. `Data.define(:miner, :value, :error)`. Always has `miner` set; exactly one of `value` or `error` is non-nil. Helpers: `.success(miner, value)`, `.failure(miner, error)`, `#ok?`, `#failed?`, `#raise!`.
+
+`Data.define` gives `==`, `hash`, `eql?`, `inspect`, `to_h`, and `deconstruct_keys` for free, enabling pattern matching:
+
+```ruby
+case result
+in { ok?: true,  value: }  then consume(value)
+in { ok?: false, error: }  then log(error)
+end
+```
+
+### `CgminerApiClient::PoolResult`
+**File:** `lib/cgminer_api_client/pool_result.rb`
+
+`Enumerable` wrapper around `Array<MinerResult>`. Preserves pool order. Frozen on construction.
+
+| Method | Returns |
+|---|---|
+| `each(&)` | iterates `MinerResult` instances |
+| `values` | `Array<value>` for successful results only |
+| `errors` | `Array<exception>` for failed results only |
+| `successful` | `Array<MinerResult>` where `ok?` |
+| `failed` | `Array<MinerResult>` where `failed?` |
+| `all_successful?`/`any_succeeded?`/`any_failed?` | `Boolean` |
+| `size` / `empty?` / `to_a` | obvious |
+| `[key]` | `MinerResult` by Integer index, `Miner` instance, or `"host:port"` string |
+
+## CLI
+
+### `bin/cgminer_api_client`
+**File:** `bin/cgminer_api_client` (42 lines, shebang + executable)
+
+Thin driver. Validates command name against `Miner::Commands.instance_methods`, builds a `MinerPool`, runs `pool.query`, prints per-miner output, exits. See [architecture.md](architecture.md#what-the-cli-adds-on-top) and [workflows.md](workflows.md#cli-request-flow) for details.
+
+## Test-only components (not packaged in the gem)
+
+### `FakeCgminer`
+**File:** `spec/support/fake_cgminer.rb`
+
+Tiny TCP server used by integration specs and the `script/fake_cgminer` manual sandbox. Accepts a connection, reads a JSON request, looks up the command name in a fixtures hash, writes the canned response, and closes the socket. Connection lifecycle deliberately mirrors real cgminer's write-then-EOF pattern so `Miner#perform_request`'s read-to-EOF call returns.
+
+Resilient to per-connection errors: a malformed request won't take down the server. Closes the listening socket first on `#stop` because on macOS `Thread#kill` doesn't interrupt a thread blocked in C-level `accept`. Has a `.with(**)` class helper that brackets a block with start/stop, handy for specs.
+
+### `CgminerFixtures`
+**File:** `spec/support/cgminer_fixtures.rb`
+
+Canned cgminer wire-format JSON responses for `summary`, `devs`, `pools`, multi-command `summary+pools`, control-byte `pools`, `addpool`, `privileged` OK, `privileged` denied, and a synthesizer for unknown-command replies. Fixtures are grounded in cgminer's actual `codes[]` table in `cgminer/api.c` (message codes, status letters, envelope shape).
+
+### `script/fake_cgminer`
+**File:** `script/fake_cgminer`
+
+Standalone foreground wrapper around `FakeCgminer`. Starts a server on port 4028 (or a port argument), prints the commands it knows, and sleeps until `Ctrl-C`. Lives in `script/` rather than `bin/` so it isn't packaged with the gem.

--- a/docs/data_models.md
+++ b/docs/data_models.md
@@ -1,0 +1,226 @@
+# Data Models
+
+The gem has no database, no schema migrations, no ORM. "Data models" here means the runtime value objects that flow through the public API.
+
+## Object graph
+
+```mermaid
+classDiagram
+    class Miner {
+        +host: String
+        +port: Integer
+        +timeout: Integer
+        +query(method, *params)
+        +available?()
+        +method_missing(name, *)
+        -perform_request(request)
+        -check_status(data)
+        -sanitized(data)
+    }
+
+    class MinerPool {
+        +miners: Array~Miner~
+        +query(method, *params) PoolResult
+        +summary() PoolResult
+        +available_miners() Array~Miner~
+        +unavailable_miners() Array~Miner~
+        +reload_miners!()
+    }
+
+    class MinerResult {
+        <<Data.define>>
+        +miner: Miner
+        +value: Object?
+        +error: StandardError?
+        +ok?() Boolean
+        +failed?() Boolean
+        +raise!() Object
+    }
+
+    class PoolResult {
+        <<Enumerable>>
+        +results: Array~MinerResult~
+        +values() Array
+        +errors() Array~StandardError~
+        +successful() Array~MinerResult~
+        +failed() Array~MinerResult~
+        +all_successful?() Boolean
+        +any_succeeded?() Boolean
+        +any_failed?() Boolean
+        +[key]() MinerResult
+    }
+
+    class Error {
+        <<StandardError>>
+    }
+    class ConnectionError {
+        <<transport>>
+    }
+    class TimeoutError {
+        <<connect timeout>>
+    }
+    class ApiError {
+        <<protocol>>
+    }
+
+    MinerPool "1" *-- "many" Miner : owns
+    MinerPool ..> PoolResult : returns
+    PoolResult "1" *-- "many" MinerResult : contains
+    MinerResult "1" --> "1" Miner : references
+    Miner ..> ConnectionError : raises
+    Miner ..> ApiError : raises
+    ConnectionError --|> Error
+    TimeoutError --|> ConnectionError
+    ApiError --|> Error
+```
+
+## `Miner`
+
+Regular Ruby class with three mutable attrs (`host`, `port`, `timeout`) and methods mixed in from `Miner::Commands` and `SocketWithTimeout`. Not immutable — `attr_accessor` deliberately allows runtime reassignment, though that's rarely useful. Equality is object-identity (no `==` override).
+
+## `MinerPool`
+
+Regular Ruby class. Holds `@miners: Array<Miner>`. Built from `config/miners.yml`. Equality is object-identity. Not thread-safe to mutate (`reload_miners!`) concurrently with `query`.
+
+## `MinerResult` (`Data.define`)
+
+Immutable value object with three fields: `miner`, `value`, `error`. Always carries exactly one of `value` or `error` (never both, never neither).
+
+### Invariants
+
+```
+MinerResult.success(miner, v)  ⇒  miner=m, value=v,   error=nil,  ok?=true,  failed?=false
+MinerResult.failure(miner, e)  ⇒  miner=m, value=nil, error=e,    ok?=false, failed?=true
+```
+
+### Inherited from `Data.define`
+
+- `#==`, `#eql?`, `#hash` — value equality based on all three fields.
+- `#to_h` — `{miner: ..., value: ..., error: ...}`.
+- `#inspect` — `#<data CgminerApiClient::MinerResult miner=..., value=..., error=...>`.
+- `#deconstruct_keys(keys)` — enables pattern matching.
+- Immutable; no setters.
+
+### Defined methods
+
+| Method | Purpose |
+|---|---|
+| `MinerResult.success(miner, value)` | Build a success. `error` defaults to nil. |
+| `MinerResult.failure(miner, error)` | Build a failure. `value` defaults to nil. |
+| `#ok?` | `error.nil?` |
+| `#failed?` | `!ok?` |
+| `#raise!` | re-raise `error` if failed; return `value` if successful |
+
+### Pattern matching
+
+```ruby
+case result
+in { ok?: true,  value: }  then consume(value)
+in { ok?: false, error: }  then log(error)
+end
+```
+
+## `PoolResult`
+
+Enumerable wrapper around `Array<MinerResult>`. Frozen on construction (`@results.freeze`). Value equality (`#==` compares underlying arrays, `#eql?` is aliased to `#==`, `#hash` delegates to the underlying array).
+
+### Invariants
+
+- `results` is frozen and has one entry per miner in pool order.
+- Order of `PoolResult#each` == pool order == order of `MinerPool#miners`.
+- `successful ⊂ results`, `failed ⊂ results`, `successful ⊍ failed = results`, `successful ∩ failed = ∅`.
+- `all_successful? = failed.empty?`, `any_failed? = !failed.empty?`.
+- `values = successful.map(&:value)` (never contains nil unless a miner genuinely returned nil).
+- `errors = failed.map(&:error)` (every entry is a StandardError subclass).
+
+### Methods
+
+| Method | Signature | Returns |
+|---|---|---|
+| `#each(&)` | yields `MinerResult` instances | self |
+| `#size` | | `Integer` |
+| `#empty?` | | `Boolean` |
+| `#to_a` | | `Array<MinerResult>` (duped) |
+| `#values` | | `Array<value>` — successes only |
+| `#errors` | | `Array<StandardError>` — failures only |
+| `#successful` | | `Array<MinerResult>` |
+| `#failed` | | `Array<MinerResult>` |
+| `#all_successful?` | | `Boolean` |
+| `#any_succeeded?` | | `Boolean` |
+| `#any_failed?` | | `Boolean` |
+| `#[](key)` | `Integer`, `Miner`, or `String` | `MinerResult` or `nil` |
+| `#==`, `#eql?`, `#hash` | | value-equality |
+| `#results` | | the frozen array (read-only attr) |
+
+`#[](key)` dispatch:
+- `Integer` → `results[key]` (supports negative indexes).
+- `String` → `find { |r| "#{r.miner.host}:#{r.miner.port}" == key }`.
+- Anything else → `find { |r| r.miner == key }` (works for a `Miner` instance).
+
+### What can be in `value`?
+
+Whatever `Miner#query` returned for that command. For `MinerPool#summary`/`#coin`/`#config`/`#version`, the `unwrap_first` override replaces each value with `value.first` so consumers get a `Hash` instead of `[Hash]`. For everything else, value is the same shape the cgminer wire format produces, after key sanitization.
+
+### What can be in `error`?
+
+Any `StandardError` raised inside a worker thread during the pool query. In practice this is almost always `ConnectionError` (transport failure) or `ApiError` (cgminer rejected the command). Unexpected `StandardError`s (bugs) are *also* captured rather than re-raised, because the thread-local rescue in `MinerPool#query` is `rescue StandardError => e`.
+
+## Error classes
+
+All declared in `lib/cgminer_api_client/errors.rb`. Plain classes, no fields beyond what `StandardError` provides.
+
+```mermaid
+classDiagram
+    StandardError <|-- Error
+    Error <|-- ConnectionError
+    Error <|-- ApiError
+    ConnectionError <|-- TimeoutError
+
+    class Error {
+        <<CgminerApiClient::Error>>
+        base for all gem errors
+    }
+    class ConnectionError {
+        transport-level failure
+        DNS, refused, unreachable, etc.
+    }
+    class TimeoutError {
+        connect timed out specifically
+    }
+    class ApiError {
+        cgminer STATUS=E or STATUS=F
+        message format: "Code: Msg"
+    }
+```
+
+Where they're raised:
+
+| Exception | Raised by | Trigger |
+|---|---|---|
+| `TimeoutError` | `SocketWithTimeout#open_socket` | `socket.wait_writable(timeout)` returned nil |
+| `ConnectionError` | `Miner#perform_request` | any `StandardError` from `open_socket`, re-wrapped |
+| `ApiError` | `Miner#check_status` | STATUS letter was E or F |
+
+## Raw response shape (before the gem touches it)
+
+Every response from cgminer has this skeleton:
+
+```json
+{
+  "STATUS": [{ "STATUS": "S", "When": 1700000000, "Code": 11, "Msg": "Summary", "Description": "cgminer 4.11.1" }],
+  "<COMMAND>": [ ... ],
+  "id": 1
+}
+```
+
+After `Miner#sanitized`, keys are lowercased + `_`-separated + symbolized:
+
+```ruby
+{
+  status: [{status: "S", when: 1700000000, code: 11, msg: "Summary", description: "cgminer 4.11.1"}],
+  summary: [{elapsed: 12345, mhs_av: 56789.12, ...}],
+  id: 1
+}
+```
+
+For most `ReadOnly` commands, the `Commands` module's `query(:name)[0]` unwrap extracts the inner array and the caller sees only the unwrapped hash (not the envelope). For `devs`/`stats`/`pools`/`notify`/`usbstats`/`asc(n)`/`pga(n)` the caller gets the array as-is. For multi-command (`summary+pools`), the full envelope is returned with every sub-key intact.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,85 @@
+# Dependencies
+
+## Runtime dependencies
+
+**None beyond the Ruby standard library.** The gemspec declares no `add_dependency` entries. At runtime, the gem uses only:
+
+| Stdlib module | Used by | Purpose |
+|---|---|---|
+| `json` | `Miner` | Parse and serialize cgminer wire-format messages |
+| `socket` | `SocketWithTimeout`, `Miner` | TCP client, non-blocking connect, `socket.wait_writable` |
+| `yaml` | `MinerPool` | Parse `config/miners.yml` via `YAML.safe_load_file` |
+| `pp` | `bin/cgminer_api_client` | Pretty-print per-miner responses to stdout |
+
+All four are part of the Ruby stdlib in every supported Ruby version (3.2+) and require no bundler entry.
+
+**Implications:**
+- Installing the gem pulls nothing else into the consumer's dependency tree.
+- No SemVer drift from transitive deps — if the suite passes and the gem installs, it works.
+- New runtime dependencies should be approached skeptically; the "zero runtime deps" posture is a deliberate design choice.
+
+## Development dependencies
+
+From `Gemfile`:
+
+```ruby
+group :development do
+  gem 'rake',          '>= 13.2'
+  gem 'rspec',         '>= 3.13'
+  gem 'rubocop',       '>= 1.60'
+  gem 'rubocop-rake',  '>= 0.6'
+  gem 'rubocop-rspec', '>= 2.27'
+  gem 'simplecov',     '>= 0.22'
+end
+```
+
+### Purpose of each
+
+| Gem | Used for |
+|---|---|
+| `rake` | Task runner; `Rakefile` defines `default: [spec, rubocop]`, plus `test` alias for `spec` |
+| `rspec` | Test framework (unit + integration). Required by `spec_helper.rb` |
+| `rubocop` | Linter. Config in `.rubocop.yml`. `TargetRubyVersion: 3.2` |
+| `rubocop-rake` | RuboCop cops for Rake tasks |
+| `rubocop-rspec` | RuboCop cops for RSpec style |
+| `simplecov` | Code coverage. Started in `spec_helper.rb` with a single `/spec/` filter; reports to `coverage/` |
+
+### Resolved versions (from `Gemfile.lock`)
+
+Current lockfile pins:
+
+- `rake 13.3.1`, `rspec 3.13.2`, `rubocop 1.86.0`, `rubocop-rspec 3.9.0`, `rubocop-rake 0.7.1`, `simplecov 0.22.0`
+- Bundler: `4.0.9`
+
+Indirect deps (from lockfile): `ast`, `diff-lcs`, `docile`, `json`, `language_server-protocol`, `lint_roller`, `parallel`, `parser`, `prism`, `racc`, `rainbow`, `regexp_parser`, `rspec-{core,expectations,mocks,support}`, `rubocop-ast`, `ruby-progressbar`, `simplecov-html`, `simplecov_json_formatter`, `unicode-display_width`, `unicode-emoji`.
+
+`pry` was removed from development deps in 0.3.0 as unused.
+
+## CI infrastructure
+
+- **GitHub Actions** (`.github/workflows/ci.yml`): runs `bundle exec rake` on ubuntu-24.04 across the Ruby matrix.
+- **Matrix:** 3.2, 3.3, 3.4, 4.0 (required), and `head` (allowed to fail as an early-warning signal).
+- **Caching:** `ruby/setup-ruby@v1` with `bundler-cache: true` for gem caching.
+
+Travis CI (`.travis.yml`) and WhiteSource Bolt (`.whitesource`) were removed in 0.3.0. If SCA is wanted later, add Dependabot via `.github/dependabot.yml` — the 0.3.0 changelog flags this as the intended path.
+
+## Ruby version support
+
+- **Minimum: Ruby 3.2.** Enforced by `spec.required_ruby_version = ">= 3.2"` in the gemspec.
+- **Local dev pin: Ruby 4.0.2** via `.ruby-version`. Only affects contributors' shells; does not constrain gem consumers.
+- **CI tests:** 3.2, 3.3, 3.4, 4.0, head.
+- **Why 3.2?** `Data.define` (used by `MinerResult`) requires 3.2+. `socket.wait_writable(timeout)` requires 3.0+. Pattern matching (`in { key: }`) requires 3.0+.
+
+**Compatibility gotchas to watch for:**
+- `pp`'s output format for symbol-keyed hashes changed in Ruby 3.4 (`:k=>v` → `k: v`). The CLI integration tests (`spec/integration/cli_spec.rb`) handle both formats — don't assert on exact punctuation.
+- `Data.define` is newer than most Ruby literature; if a future feature needs struct-like value types, stick with `Data.define` over custom classes or `Struct`.
+
+## External dependencies
+
+**cgminer itself**, obviously. The gem targets cgminer's JSON API wire format as documented in [cgminer's API-README](https://github.com/ckolivas/cgminer/blob/master/API-README). Fixtures in `spec/support/cgminer_fixtures.rb` are grounded in cgminer 4.11.1's `codes[]` table from `cgminer/api.c`. The wire format has been stable for years; breakage due to cgminer API changes is unlikely but not impossible.
+
+## Dependency update strategy
+
+The gem has no Dependabot or Renovate configured. Manual dep bumps happen as part of release work. Minimum version constraints in the Gemfile are intentionally set a floor-or-above (`rake >= 13.2`, `rspec >= 3.13`, etc.) so Bundler resolves recent versions without over-constraining.
+
+The gem's own consumers should treat `cgminer_api_client` as a zero-transitive-footprint dep — installing it adds exactly one gem to their lockfile.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,72 @@
+# Knowledge Base Index — `cgminer_api_client`
+
+**This file is the entry point for AI assistants working on this gem.** It summarizes every other document in `docs/summary/` so an assistant can pull in only the file(s) relevant to a given question. When no single file is an obvious fit, read `AGENTS.md` (consolidated, at repo root) or skim `codebase_info.md` first.
+
+## How to use this index
+
+1. **Identify the question category** from the table below (Architecture? Public API? Error handling? Dev workflow?).
+2. **Read the mapped file.** Each mapping includes a one-line "use this when" hook plus a brief summary.
+3. **Cross-reference** via the explicit links between documents — they are maintained.
+4. **Fall back** to reading the code. All docs are derived from `lib/` and `spec/`; if a doc and the code disagree, the code is truth and the doc is stale (report it).
+
+## Question → file map
+
+| If the question is about... | Start here |
+|---|---|
+| "what is this project?" / stack / directory layout / Ruby version / coverage | [`codebase_info.md`](codebase_info.md) |
+| design patterns / mixin layout / why `method_missing` / why `Data.define` / CLI contract | [`architecture.md`](architecture.md) |
+| what each class or module does / responsibilities / where to find X | [`components.md`](components.md) |
+| public API shape / method signatures / CLI exit codes / `config/miners.yml` format / wire protocol | [`interfaces.md`](interfaces.md) |
+| `MinerResult` / `PoolResult` invariants / error hierarchy / object graph | [`data_models.md`](data_models.md) |
+| request flow / parallel pool fan-out / CLI execution / running tests / release process | [`workflows.md`](workflows.md) |
+| gem deps / Ruby version support / CI matrix | [`dependencies.md`](dependencies.md) |
+| known gaps, inconsistencies, caveats in the docs themselves | [`review_notes.md`](review_notes.md) |
+
+## Document summaries
+
+### [`codebase_info.md`](codebase_info.md)
+**Purpose:** The one-pager. What the gem is, what Ruby versions it supports, what the file tree looks like, and which files are packaged in the gem vs. which are dev-only. Has a high-level module graph. **Start here if you've never seen the project.**
+
+### [`architecture.md`](architecture.md)
+**Purpose:** Why the code is shaped the way it is. Covers: the mixin-driven command surface (`Miner` and `MinerPool` both `include Miner::Commands`), `method_missing` fallback for uncommon cgminer commands, `Data.define` for `MinerResult`, the parallel-fan-out-with-capture-everything pattern, the dual error taxonomy (`ConnectionError` vs `ApiError`), the cgminer wire protocol that the gem speaks, and the single-miner-convenience-unwrap fix that `MinerPool` overrides for `summary`/`coin`/`config`/`version`/`check`. **Read this before making non-trivial code changes.**
+
+### [`components.md`](components.md)
+**Purpose:** Catalog of every file in `lib/` (and the two test-only helpers `FakeCgminer` + `CgminerFixtures`). Each entry lists the file path, primary responsibility, and key public methods. **Read this to find where a specific piece of behavior lives.**
+
+### [`interfaces.md`](interfaces.md)
+**Purpose:** Contract reference — exhaustive. Every public method on `Miner`, `MinerPool`, `MinerResult`, `PoolResult`. Every CLI command/exit-code/stream contract. The `config/miners.yml` schema. The upstream cgminer wire protocol (request/response envelope, STATUS codes). **Read this when asked about method signatures, CLI behavior, or wire format.**
+
+### [`data_models.md`](data_models.md)
+**Purpose:** Runtime value object graph. `MinerResult` and `PoolResult` methods, invariants, and pattern-match shape. Error class hierarchy. Raw vs. sanitized response shapes. **Read this for questions about "what comes back" or "what's in this object".**
+
+### [`workflows.md`](workflows.md)
+**Purpose:** Sequence diagrams and step-by-step flows. Single-miner request path (socket → response → parse → check_status → sanitize). Parallel pool query with `Thread`-per-miner fan-out and `MinerResult`-capture semantics. CLI invocation end-to-end. Development workflow (tests, integration with `FakeCgminer`, manual sandbox, RuboCop, release). **Read this to understand how code paths compose over time.**
+
+### [`dependencies.md`](dependencies.md)
+**Purpose:** Runtime (none; stdlib only) and dev deps with rationale. Resolved versions from `Gemfile.lock`. CI matrix. Ruby version rationale (why 3.2+). External cgminer dependency. **Read this for "can I add gem X?" or "what Rubies does this support?".**
+
+### [`review_notes.md`](review_notes.md)
+**Purpose:** Self-audit. Known inconsistencies, documentation gaps, and areas where the analysis couldn't reach definitive answers. **Read this when validating the rest of the docs, or before trusting a claim made elsewhere in `docs/summary/`.**
+
+## Example queries and where to go
+
+| Query | Primary file(s) |
+|---|---|
+| "How do I add a new cgminer command wrapper?" | `components.md` (see `Miner::Commands`), `architecture.md` (mixin pattern) |
+| "Why doesn't `pool.summary` just return an array of hashes like in 0.2.x?" | `data_models.md` (PoolResult) + `architecture.md` (Single-miner convenience unwrap) + `CHANGELOG.md` |
+| "What happens if a single miner is unreachable during `pool.restart`?" | `workflows.md` (Parallel pool request flow) + `data_models.md` (MinerResult failure shape) |
+| "Can I run the CLI without real miners?" | `workflows.md` (Manual sandbox section) |
+| "How is `connect_nonblock` with timeout implemented?" | `components.md` (`SocketWithTimeout`) + the source file itself |
+| "What Ruby versions does this gem support and why?" | `dependencies.md` |
+| "Where do cgminer's STATUS letters map to exception classes?" | `interfaces.md` (wire protocol) + `architecture.md` (dual error taxonomy) |
+| "What's the CLI exit code when one of three miners fails?" | `interfaces.md` (CLI section) — partial success is exit 0 |
+
+## Maintenance note
+
+The docs in this directory were generated by analyzing the code directly. They reflect the state at gem version 0.3.0. When the code changes substantially:
+
+- Prefer updating the specific file that contains the affected claim (smaller diffs, clearer history).
+- Update `review_notes.md` if you find a new inconsistency or gap.
+- Re-run the codebase-summary skill in `update_mode` if the surface area has shifted enough to warrant a re-analysis.
+
+If you're an AI assistant and you find a doc that contradicts the current code, **trust the code** and flag the discrepancy to the human maintainer rather than silently fixing the doc.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1,0 +1,308 @@
+# Interfaces
+
+The gem exposes three public surfaces: the Ruby library, the `bin/cgminer_api_client` CLI, and the `config/miners.yml` file schema. Internally, it consumes the cgminer JSON-over-TCP API, which is documented briefly here for context on what the gem translates between.
+
+## 1. Ruby library API
+
+### Top-level module: `CgminerApiClient`
+
+```ruby
+require 'cgminer_api_client'
+
+CgminerApiClient.default_host        # "127.0.0.1"
+CgminerApiClient.default_port        # 4028
+CgminerApiClient.default_timeout     # 5
+
+CgminerApiClient.default_host = '192.168.1.1'
+CgminerApiClient.default_port = 4028
+CgminerApiClient.default_timeout = 3
+
+CgminerApiClient.config do |c|
+  c.default_port = 4028
+  c.default_timeout = 3
+end
+```
+
+`.config` simply yields `self` if given a block, so `CgminerApiClient.config { ... }` and `CgminerApiClient.default_port = 4028` are interchangeable.
+
+### Single-miner client: `CgminerApiClient::Miner`
+
+```ruby
+miner = CgminerApiClient::Miner.new            # uses module defaults
+miner = CgminerApiClient::Miner.new('10.0.0.5')
+miner = CgminerApiClient::Miner.new('10.0.0.5', 4028)
+miner = CgminerApiClient::Miner.new('10.0.0.5', 4028, 3)
+
+miner.host       # "10.0.0.5"
+miner.port       # 4028
+miner.timeout    # 3
+```
+
+Any of the three constructor args can be omitted/nil; the corresponding `CgminerApiClient.default_*` value is used.
+
+**Commands (all return the parsed, sanitized response on success; raise `ConnectionError` on transport failure, `ApiError` on cgminer rejection):**
+
+```ruby
+miner.summary                              # Hash
+miner.stats                                # Array<Hash>
+miner.pools                                # Array<Hash>
+miner.devs                                 # Array<Hash>
+miner.devdetails                           # Array<Hash>
+miner.coin                                 # Hash
+miner.config                               # Hash
+miner.version                              # Hash
+miner.check('summary')                     # Hash
+miner.notify                               # Array<Hash>
+miner.usbstats                             # Array<Hash>
+miner.privileged                           # true | false (API denied)
+miner.asc(0)                               # Array<Hash>
+miner.asccount                             # Array<Hash>
+miner.pga(0)                               # Array<Hash>
+miner.pgacount                             # Array<Hash>
+
+# Privileged (require privileged API access on the miner; raise if not)
+miner.addpool(url, user, pass)
+miner.removepool(number)
+miner.switchpool(number)
+miner.enablepool(number)
+miner.disablepool(number)
+miner.poolpriority(*id_order)
+miner.poolquota(number, value)
+miner.ascenable(number)
+miner.ascdisable(number)
+miner.ascidentify(number)
+miner.ascset(number, option, value = nil)
+miner.pgaenable(number)
+miner.pgadisable(number)
+miner.pgaidentify(number)
+miner.pgaset(number, option, value = nil)
+miner.restart
+miner.quit
+miner.save(filename = nil)
+miner.setconfig(name, value)
+miner.debug(setting = 'D')
+miner.failover_only(value)
+miner.hotplug(seconds)
+miner.zero(which = 'All', full_summary = false)
+
+# Any not-yet-wrapped command still works via method_missing:
+miner.some_cgminer_command('a', 'b')
+
+# Reachability probe (opens a fresh socket every call, no cache):
+miner.available?                           # true | false
+
+# Low-level escape hatch:
+miner.query(:summary)                      # returns parsed Hash/Array
+miner.query('summary+pools')               # multi-command syntax (keeps nested shape)
+miner.query(:ascset, 0, 'freq', 650)       # positional params → comma-joined & escaped
+```
+
+**Key normalization:** cgminer response keys like `"MHS av"`, `"Found Blocks"`, `"Last Share Time"` are normalized to `:mhs_av`, `:found_blocks`, `:last_share_time` before being returned. Arrays and nested hashes are recursively processed.
+
+**Pattern match for unknown commands:**
+
+```ruby
+miner.respond_to?(:summary)             # true  (real method)
+miner.respond_to?(:some_weird_cmd)      # true  (via respond_to_missing?)
+miner.respond_to?(:to_ary)              # false (to_* is carved out)
+miner.respond_to?(:_dump)               # false (_* is carved out)
+```
+
+### Pool client: `CgminerApiClient::MinerPool`
+
+```ruby
+pool = CgminerApiClient::MinerPool.new       # reads ./config/miners.yml
+pool.miners                                  # Array<Miner> in config order
+pool.reload_miners!                          # re-read config/miners.yml
+```
+
+**Commands (same surface as `Miner`; all return a `PoolResult` of `MinerResult`s):**
+
+```ruby
+pool.summary                                 # PoolResult (successful values are Hashes)
+pool.stats                                   # PoolResult (successful values are Arrays)
+pool.restart                                 # PoolResult
+pool.addpool(url, user, pass)                # PoolResult
+# ... etc, every Miner command works on a pool.
+
+# Reachability:
+pool.available_miners                        # Array<Miner> (reachable subset, in pool order)
+pool.unavailable_miners                      # Array<Miner> (unreachable subset)
+
+# Low-level:
+pool.query(:summary)                         # PoolResult
+```
+
+**Consuming a `PoolResult`:**
+
+```ruby
+result = pool.summary
+
+# Success-only projections
+result.values            # [Hash, Hash, ...]       — successful values only
+result.successful        # [MinerResult, ...]      — ok? == true
+result.failed            # [MinerResult, ...]      — failed? == true
+result.errors            # [<ConnectionError>, ...]
+
+# Predicates
+result.all_successful?   # true if every miner ok
+result.any_succeeded?    # true if ≥1 miner ok
+result.any_failed?       # true if ≥1 miner failed
+
+# Lookup
+result[0]                        # by index
+result[miner_instance]           # by Miner instance
+result['10.0.0.5:4028']          # by "host:port" string
+
+# Iterate per-miner (default)
+result.each do |r|
+  if r.ok?
+    puts "#{r.miner.host}: #{r.value[:mhs_av]}"
+  else
+    warn "#{r.miner.host}: #{r.error.class}: #{r.error.message}"
+  end
+end
+```
+
+### `MinerResult` and `PoolResult`
+
+Both are loaded automatically by `require 'cgminer_api_client'`. See [data_models.md](data_models.md) for the full shape.
+
+### Error classes
+
+```ruby
+CgminerApiClient::Error             # < StandardError
+CgminerApiClient::ConnectionError   # < Error (transport-level)
+CgminerApiClient::TimeoutError      # < ConnectionError (connect timeout specifically)
+CgminerApiClient::ApiError          # < Error (cgminer STATUS=E or F)
+```
+
+Rescue hierarchy: `rescue CgminerApiClient::Error` catches everything gem-specific. `rescue CgminerApiClient::ConnectionError` catches both `TimeoutError` and other transport failures. `rescue CgminerApiClient::TimeoutError` catches *only* connect timeouts. All still descend from `StandardError` so existing blanket rescues keep working.
+
+## 2. CLI interface
+
+### Binary
+
+```
+cgminer_api_client <command> [<arguments>]
+```
+
+Invocation happens from a directory containing `config/miners.yml`. The CLI reads that file to build its `MinerPool`.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | at least one miner's query succeeded |
+| 1 | every miner failed, OR a top-level exception bubbled up |
+| 64 | `EX_USAGE` — unknown command or missing command argument |
+
+### stdout vs stderr
+
+| Stream | Contents |
+|---|---|
+| stdout | per-miner `host:port:` header lines, followed by the `pp`-formatted response value |
+| stderr | per-miner `host:port: ErrorClass: message` lines for failed miners; `USAGE:` and top-level error messages |
+
+Library code never writes to stderr. The CLI owns that channel. Existing shell pipelines capturing stdout get clean output even when some miners fail.
+
+### Environment variables
+
+- `DEBUG=1` — on a top-level (unhandled) exception, also print the full backtrace via `Exception#full_message(highlight: false)` to stderr.
+
+### Examples
+
+```sh
+$ cgminer_api_client summary
+10.0.0.1:4028:
+{:elapsed=>12345, :mhs_av=>56789.12, :found_blocks=>0, ...}
+10.0.0.2:4028:
+{:elapsed=>5432, :mhs_av=>56780.00, :found_blocks=>0, ...}
+
+$ cgminer_api_client restart
+10.0.0.1:4028:
+{...}
+10.0.0.2:4028: CgminerApiClient::ConnectionError: Connection to 10.0.0.2:4028 failed: Errno::ECONNREFUSED: Connection refused
+# exit code 0 (at least one succeeded)
+
+$ cgminer_api_client bogus_command
+USAGE: cgminer_api_client command (arguments)
+commands: addpool, asc, asccount, ascdisable, ...
+Set DEBUG=1 to see full backtraces on errors.
+# exit code 64
+
+$ DEBUG=1 cgminer_api_client summary
+# ... same output plus full backtrace on any unhandled exception
+```
+
+## 3. `config/miners.yml` schema
+
+Path: `./config/miners.yml` (relative to process CWD).
+
+YAML array of mappings. Each mapping:
+
+| Key | Required | Type | Default |
+|---|---|---|---|
+| `host` | yes | string (IP or hostname) | — |
+| `port` | no | integer | `CgminerApiClient.default_port` (4028) |
+| `timeout` | no | integer (seconds) | `CgminerApiClient.default_timeout` (5) |
+
+Parsed with `YAML.safe_load_file` — no custom types, symbols, or procs.
+
+Example:
+
+```yaml
+- host: 127.0.0.1                  # uses default port 4028, default timeout 5s
+- host: 192.168.1.1                # custom port and timeout
+  port: 1234
+  timeout: 3
+- host: miner3.example.com         # DNS works
+```
+
+The example file at `config/miners.yml.example` is packaged with the gem; `config/miners.yml` is `.gitignore`d.
+
+## 4. Upstream wire protocol (consumed by the gem, not exposed)
+
+The gem talks to cgminer's JSON API. This is documented at [cgminer's API-README](https://github.com/ckolivas/cgminer/blob/master/API-README) and summarized here so future changes to the gem have context.
+
+### Transport
+- TCP, default port 4028, IPv4.
+- Client writes one JSON request, reads until EOF, server closes connection.
+
+### Request shape
+```json
+{"command":"summary"}
+{"command":"ascset","parameter":"0,freq,650"}
+```
+
+### Response shape
+Single JSON object. Universal envelope:
+```json
+{
+  "STATUS": [{
+    "STATUS": "S",               // S/I/W/E/F — see table below
+    "When":   1700000000,
+    "Code":   11,                 // cgminer MSG code
+    "Msg":    "Summary",
+    "Description": "cgminer 4.11.1"
+  }],
+  "SUMMARY": [...],               // command-specific key(s); varies per command
+  "id": 1
+}
+```
+
+STATUS codes (as interpreted by `Miner#check_status`):
+
+| Letter | Meaning | Gem behavior |
+|---|---|---|
+| `S` | Success | silent |
+| `I` | Info | `puts` to stdout |
+| `W` | Warning | `puts` to stdout |
+| `E` | Error | raises `ApiError` |
+| `F` | Fatal | raises `ApiError` |
+
+### Quirks the gem handles
+1. **Control bytes in string values** (pool names, worker IDs can contain raw 0x01–0x1F). Re-escaped as `\uXXXX` before `JSON.parse`.
+2. **Malformed multi-object responses** of the form `}{` between sibling objects. Legacy repair replaces with `}, {`. May no longer fire on modern cgminer.
+3. **Single-element array responses** for `summary`/`coin`/`config`/`version`/`check`. Unwrapped by `Miner::Commands::ReadOnly`.
+4. **Multi-command syntax** (`summary+pools`). Response is a top-level object with one sub-key per subcommand; each sub-value is an array whose first element has its own STATUS block. Detected by `+` in the command name; gem calls `check_status` per sub-response.

--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -1,0 +1,85 @@
+# Review Notes
+
+Self-audit of the documentation set. This file is where I record what I'm **not** certain about, what I glossed over, and where the documentation and the code could drift. Read this before trusting a confident-sounding claim elsewhere in `docs/summary/`.
+
+## Consistency check
+
+I cross-referenced the following claims across files and found no outright contradictions:
+
+| Claim | Asserted in | Verified |
+|---|---|---|
+| `MinerPool#query` returns `PoolResult`, not an Array | `architecture.md`, `components.md`, `interfaces.md`, `data_models.md`, `workflows.md` | consistent |
+| `MinerResult` is an immutable `Data.define` | `architecture.md`, `components.md`, `data_models.md` | consistent |
+| Error hierarchy (`Error → ConnectionError → TimeoutError`, `Error → ApiError`) | `architecture.md`, `components.md`, `interfaces.md`, `data_models.md` | consistent |
+| CLI exit code 0 on partial success, 1 on all-fail, 64 on usage | `architecture.md`, `interfaces.md`, `workflows.md` | consistent |
+| Library code never writes to stderr | `architecture.md`, `interfaces.md`, `workflows.md` | consistent |
+| Single-miner response unwrap is overridden on `MinerPool` for `summary`/`coin`/`config`/`version`/`check` | `architecture.md`, `components.md`, `workflows.md` | consistent |
+| No runtime dependencies beyond stdlib | `codebase_info.md`, `architecture.md`, `dependencies.md` | consistent |
+| Ruby 3.2+ minimum, CI matrix 3.2/3.3/3.4/4.0/head | `codebase_info.md`, `dependencies.md` | consistent |
+
+Nothing I flagged as contradictory. If later edits introduce a drift, re-run this section.
+
+## Completeness gaps
+
+The following areas are **not fully covered** by the code and therefore not fully covered by the docs:
+
+### 1. Thread safety of `MinerPool` is unspecified
+`MinerPool#query` spawns threads and joins them before returning, so one call is self-contained. But the code doesn't document what happens if:
+- Two callers invoke `pool.query(...)` on the same instance concurrently.
+- A caller invokes `pool.reload_miners!` while another is mid-`query`.
+
+Reading the code, `@miners` is reassigned by `reload_miners!` — a concurrent `query` could in principle iterate a partially-replaced array, or a mix of old and new `Miner` instances. There's no mutex. In practice, the typical usage is single-threaded script or CLI, so this hasn't bitten anyone. If `MinerPool` starts being used from servers or schedulers, this deserves a real answer.
+
+### 2. Fiber-scheduler compatibility is claimed but not exercised
+`SocketWithTimeout` switched from `IO.select` to `socket.wait_writable(timeout)` in 0.3.0 specifically to be Fiber-scheduler compatible. I stated this in `architecture.md` and `components.md`. There are no tests that actually run the gem under a Fiber scheduler, so "compatible" here means "uses APIs that are compatible" rather than "verified compatible." A future contributor running under `Async` or Ruby's default scheduler should be prepared to re-verify.
+
+### 3. The `}{` → `}, {` repair in `Miner#perform_request` may be dead code
+The fixture file (`spec/support/cgminer_fixtures.rb`) flags this directly: the repair "does not actually produce valid JSON from any format I can reproduce, and may be legacy defensive code for a cgminer version that no longer exists." I repeated the claim in `architecture.md` and `interfaces.md`. Not tested with a real cgminer binary; historical reason unknown. Before removing, add a repro fixture that definitively shows the repair fires.
+
+### 4. The `[,{` repair has even less explanation
+Same code path (`response.gsub! '[,{', '[ {'`). Fires even more rarely than `}{`. Neither repair has a dedicated test. Mentioned briefly in `architecture.md` and `interfaces.md`; treated as legacy.
+
+### 5. `method_missing`'s scope for `MinerPool` is subtle
+`MinerPool#method_missing` forwards to `query(name, *args)`, which returns a `PoolResult`. That means calling an unwrapped cgminer command on a `MinerPool` gives you a `PoolResult` whose `value`s are the raw `Hash` envelopes — the five convenience overrides (`summary`/`coin`/`config`/`version`/`check`) are the only paths that unwrap. This is correct and mentioned in `interfaces.md`, but a reader might expect `method_missing` to do something similar for every "looks like it returns one hash" command. It doesn't, and that's by design — the gem can't know the shape of an arbitrary cgminer command's response at call time.
+
+### 6. No coverage of `config/miners.yml` path resolution edge cases
+`MinerPool.new` hard-codes `'config/miners.yml'` as a relative path. Docs mention it's relative to process CWD. Not discussed: behavior when the file exists but is malformed YAML, when it's an empty file, when it's an array with no entries (MinerPool with zero miners — `query` would return an empty `PoolResult`), or when a single entry is missing the required `host` key (`Miner.new(nil, ...)` falls back to `default_host`, but that's almost certainly not what the user wanted). These are real edge cases and the gem's behavior in each is determined by reading the code, not documented anywhere.
+
+### 7. `Miner::Commands::Privileged#access_denied?` raises a bare `'access_denied'` string
+From `miner/commands.rb:189`:
+```ruby
+def access_denied?
+  raise 'access_denied' unless privileged
+  false
+end
+```
+This raises a `RuntimeError` whose message is literally `'access_denied'`. It's not a `CgminerApiClient::ApiError` or any other gem-specific class, so code that does `rescue CgminerApiClient::Error` won't catch it; only `rescue StandardError` or `rescue RuntimeError` will. This is a minor inconsistency with the rest of the error taxonomy but not worth fixing on its own.
+
+The docs don't dwell on this because it's an implementation detail rather than contract, but anyone writing new privileged commands should know: the rescue gate here is a `RuntimeError`, not the gem's custom hierarchy.
+
+### 8. `Miner#check_status` writes Info/Warning to stdout
+`'I'` and `'W'` cgminer STATUS codes result in `puts "Info from API [..]: .."` / `puts "Warning..."`. That's library-code-writing-to-stdout, which slightly contradicts the "library never writes to stderr" posture stated in `architecture.md`. The claim is specifically about **stderr**; stdout for cgminer advisory messages is intended. Mentioned in `interfaces.md`, but the slight tension is worth flagging.
+
+## Language and tooling limitations
+
+- **Ruby-only.** No other languages are used. No FFI, no Rust extension, no native build step.
+- **No CI for macOS or Windows** — GitHub Actions uses `ubuntu-24.04` only. The gem is pure Ruby and stdlib, so portability is likely fine, but it's not exercised.
+- **No external service integration** to spec — the gem talks TCP to a cgminer instance. Integration is via `FakeCgminer`, which is tested-and-shipped-together but **not** automatically exercised against a real cgminer.
+- **Documentation scope.** These docs cover the gem and its CLI. They do **not** cover how to operate cgminer itself. For that, see cgminer's own docs or the linked API-README.
+
+## Recommendations
+
+Low effort, high value:
+1. Add a test that exercises `MinerPool` with zero miners in `config/miners.yml` (confirms the "empty PoolResult" behavior).
+2. Add a test for `MinerPool#query` behavior when `config/miners.yml` is missing a `host` key.
+3. Document `access_denied?`'s rescue-gate behavior somewhere less deep than the source file — CHANGELOG or a code comment.
+
+Higher effort, might not be worth it:
+4. Decide whether the `}{` / `[,{` repair code paths should be kept (with a repro) or deleted (with a changelog note).
+5. Add a thread-safety section to the architecture docs if real-world users report the concurrent-query case.
+
+## How I validated
+
+- Read every file under `lib/`, `bin/`, `spec/support/`, and the top-level `config/`, `Gemfile`, `Gemfile.lock`, `.github/workflows/`, `.rubocop.yml`, `Rakefile`, `CHANGELOG.md`, `README.md`, `.rspec`, `.ruby-version`, and the gemspec.
+- Did not read the unit specs' full bodies (only counted lines and spot-checked one). The behavioral claims in the docs are from the source files themselves, not derived from the spec assertions.
+- Did not run the test suite as part of writing these docs. All claims about "tested" behavior are from reading the spec files' existence and inferred coverage, not from a pass/fail run.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,203 @@
+# Workflows
+
+Three request flows cover essentially everything the gem does: single-miner query, parallel pool query, and CLI invocation. Plus two dev/test workflows: running the suite against a fake cgminer, and a manual sandbox loop.
+
+## 1. Single-miner request flow (`Miner#query`)
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Miner
+    participant SWT as SocketWithTimeout
+    participant cgminer
+
+    Caller->>Miner: miner.summary
+    Note over Miner: ReadOnly#summary → query(:summary)[0]
+    Miner->>Miner: build {command: :summary} (add :parameter if params)
+    Miner->>SWT: open_socket(host, port, timeout)
+    alt connect OK
+        SWT-->>Miner: Socket
+    else connect timeout
+        SWT--xMiner: TimeoutError
+        Miner--xCaller: ConnectionError (re-wrapped)
+    else other connect failure
+        SWT--xMiner: SocketError / SystemCallError
+        Miner--xCaller: ConnectionError (re-wrapped)
+    end
+    Miner->>cgminer: write(request.to_json)
+    cgminer-->>Miner: JSON response + EOF
+    Miner->>Miner: re-escape control bytes < 0x20
+    Miner->>Miner: gsub repairs for '}{' & '[,{'
+    Miner->>Miner: JSON.parse(response)
+    Miner->>Miner: check_status(data) — raise ApiError on E/F
+    Miner->>Miner: sanitized(data) — keys lowercased + symbolized
+    Miner-->>Caller: data[:summary] — or full hash for multi-command
+```
+
+**Key observations:**
+- No retries, ever. Caller decides whether to retry.
+- No connection reuse. Every call opens and closes a fresh socket.
+- Read-to-EOF pattern. Server closing the socket is what signals "response complete."
+- `Miner#query` only raises `ConnectionError` or `ApiError` (or a bug like `ArgumentError` if misused); cgminer `STATUS=I`/`STATUS=W` just print a line and continue.
+
+## 2. Parallel pool request flow (`MinerPool#query`)
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant MinerPool
+    participant Thread_A as Thread #0
+    participant Thread_B as Thread #1
+    participant Thread_N as Thread #N
+    participant Miner_A as Miner #0
+    participant Miner_B as Miner #1
+    participant Miner_N as Miner #N
+    participant PoolResult
+
+    Caller->>MinerPool: pool.summary
+    Note over MinerPool: summary = unwrap_first(query(:summary))
+    MinerPool->>Thread_A: Thread.new { Miner_A.query(:summary) }
+    MinerPool->>Thread_B: Thread.new { Miner_B.query(:summary) }
+    MinerPool->>Thread_N: Thread.new { Miner_N.query(:summary) }
+
+    par Miner #0
+        Thread_A->>Miner_A: miner.query(:summary)
+        alt success
+            Miner_A-->>Thread_A: [hash]
+            Thread_A-->>Thread_A: MinerResult.success(miner, [hash])
+        else transport / api failure
+            Miner_A--xThread_A: ConnectionError / ApiError
+            Thread_A-->>Thread_A: MinerResult.failure(miner, e)
+        end
+    and Miner #1
+        Thread_B->>Miner_B: miner.query(:summary)
+        Miner_B-->>Thread_B: result
+    and Miner #N
+        Thread_N->>Miner_N: miner.query(:summary)
+        Miner_N-->>Thread_N: result
+    end
+
+    MinerPool->>MinerPool: threads.each(&:join)
+    MinerPool->>MinerPool: threads.map(&:value) — in original pool order
+    MinerPool->>PoolResult: new(results)
+    MinerPool->>MinerPool: unwrap_first(pool_result) for summary/coin/config/version/check
+    MinerPool-->>Caller: PoolResult
+```
+
+**Key observations:**
+- Each miner runs in its own `Thread`. True concurrency for I/O since `open_socket`, `socket.wait_writable`, `s.read` all release the GVL.
+- Thread-local `rescue StandardError => e` turns **any** failure into a `MinerResult.failure`. The caller's pool query never itself raises a per-miner error (barring a bug outside the rescue, in which case `Thread#value` re-raises to the caller).
+- `threads.map(&:value)` preserves pool order because the threads array preserves iteration order.
+- `unwrap_first` is the final step for the five ReadOnly convenience methods (`summary`, `coin`, `config`, `version`, `check`). It walks the `PoolResult`, replacing each successful `MinerResult.value` with `value.first`. Failures pass through untouched.
+
+## 3. CLI invocation flow (`bin/cgminer_api_client`)
+
+```mermaid
+flowchart TD
+    A[user runs cgminer_api_client CMD ARGS] --> B{command given?}
+    B -- no --> Usage1[print USAGE to stderr<br/>exit 64]
+    B -- yes --> C{command ∈ Miner::Commands.instance_methods?}
+    C -- no --> Usage1
+    C -- yes --> D[CgminerApiClient::MinerPool.new]
+    D -->|reads config/miners.yml| E[pool.query command, *ARGS]
+    E --> F[iterate PoolResult]
+    F --> G{result.ok?}
+    G -- yes --> H["puts 'host:port:' header, pp r.value"]
+    G -- no --> I["warn 'host:port: ErrClass: message' to stderr"]
+    H --> J{more results?}
+    I --> J
+    J -- yes --> F
+    J -- no --> K{any miner succeeded?}
+    K -- yes --> L[exit 0]
+    K -- no --> M[exit 1]
+
+    %% Top-level rescue
+    D -.any StandardError.-> N["warn CLI-level error to stderr;<br/>full_message if DEBUG=1;<br/>exit 1"]
+    E -.any StandardError.-> N
+```
+
+**Key observations:**
+- The CLI is the only code path that writes to stderr. Library code never does.
+- Command validation is against `Miner::Commands.instance_methods`, which means every real cgminer command wrapped by `ReadOnly`/`Privileged` modules is callable from CLI. Unwrapped commands (those only reachable via `method_missing`) are not callable from CLI — this is by design.
+- Top-level exceptions (e.g. `"Please create config/miners.yml"`) land in the outer `rescue StandardError` and produce exit 1 with the error on stderr.
+- `DEBUG=1` enables full backtraces via `Exception#full_message(highlight: false)`. Without it, only the error class and message are shown.
+- Partial success is explicitly a success (exit 0). Fleet-oriented tooling pattern — partial failures don't trigger alerts.
+
+## 4. Development workflow
+
+### Running tests
+
+```sh
+bundle install
+bundle exec rspec                      # unit + integration
+bundle exec rspec spec/cgminer_api_client  # unit only
+bundle exec rspec spec/integration     # integration only
+bundle exec rake                       # spec + rubocop (the default task)
+```
+
+**Coverage** is enabled automatically via SimpleCov (see `spec/spec_helper.rb`). Reports land in `coverage/`.
+
+**RSpec config** (`.rspec`): `--color --warnings --require spec_helper`. Warnings are deliberately on — the suite is expected to run warning-clean.
+
+### Integration tests
+
+`spec/integration/miner_integration_spec.rb` exercises the full `Miner` request path against `FakeCgminer` running in a background thread in the same process. `spec/integration/cli_spec.rb` uses `Open3.capture3` to spawn the real `bin/cgminer_api_client` and assert on exit codes and stdout/stderr split.
+
+```mermaid
+sequenceDiagram
+    participant Spec
+    participant FakeCgminer
+    participant Miner
+
+    Spec->>FakeCgminer: FakeCgminer.with { |port| ... }
+    FakeCgminer->>FakeCgminer: TCPServer on 127.0.0.1:ephemeral
+    FakeCgminer->>FakeCgminer: Thread.new { accept_loop }
+    Spec->>Miner: Miner.new('127.0.0.1', port)
+    Spec->>Miner: miner.summary
+    Miner->>FakeCgminer: TCP connect + write request
+    FakeCgminer->>FakeCgminer: JSON.parse(request)
+    FakeCgminer->>FakeCgminer: lookup canned response
+    FakeCgminer-->>Miner: write response + close
+    Miner-->>Spec: parsed hash
+    Spec->>Spec: assertions
+    Note over Spec,FakeCgminer: on block exit:<br/>server.close, thread.join
+```
+
+### Manual sandbox (`script/fake_cgminer`)
+
+Same `FakeCgminer` server, but foreground and long-running. Useful for exercising the CLI end-to-end without real mining hardware.
+
+```sh
+# terminal 1
+./script/fake_cgminer 4028
+# → fake cgminer listening on 127.0.0.1:4028
+# → commands available: addpool, devs, pools, privileged, summary, summary+pools
+
+# terminal 2
+cp config/miners.yml.example config/miners.yml   # points at 127.0.0.1:4028
+bundle exec bin/cgminer_api_client summary
+# ... inspect output, iterate
+```
+
+### Linting
+
+```sh
+bundle exec rubocop                    # check
+bundle exec rubocop -A                 # auto-correct (with caution)
+```
+
+`.rubocop.yml` turns off most `Metrics/*` cops (the gem is small and the defaults fight it without adding value) and the `RSpec/*` style cops (the existing suite uses idiomatic-for-its-time patterns). Correctness cops (`RSpec/RepeatedExample`, `RSpec/LeakyConstantDeclaration`, etc.) are deliberately left on — don't disable them without a specific reason.
+
+## 5. Release / publish flow
+
+Not automated. Manual process on a clean `master`:
+
+```sh
+bundle exec rake                                 # must pass
+gem build cgminer_api_client.gemspec             # produces cgminer_api_client-X.Y.Z.gem
+gem push cgminer_api_client-X.Y.Z.gem            # requires 2FA because rubygems_mfa_required
+git tag vX.Y.Z
+git push origin master vX.Y.Z
+```
+
+A `cgminer_api_client-0.3.0.gem` artifact is currently present at the repo root (untracked) from the 0.3.0 release.


### PR DESCRIPTION
## Overview

Adds an AI-assistant knowledge base under `docs/` with a consolidated `AGENTS.md` at the repo root, and refreshes the README with operator-facing details that were previously only in the CHANGELOG.

## Questions/Comments

The motivation for the `docs/` + `AGENTS.md` work is context rot — every new assistant session, and every new human contributor, re-learns the same handful of things from the source (why `Miner` and `MinerPool` share a command mixin, why `MinerPool` has to override `summary`/`coin`/`config`/`version`/`check`, what the cgminer STATUS letter → gem exception mapping is). Pinning those down in versioned docs turns rediscovery into a lookup, and a `review_notes.md` at the bottom of the set records what I'm *not* sure about so the docs stay honest as the code moves.

The README refresh solves the same problem for humans rather than agents: a CLI user shouldn't have to grep the CHANGELOG to learn that exit 0 means "at least one miner succeeded" or that `DEBUG=1` prints backtraces on errors. The new Errors and Exit Codes subsections plus a Further Reading pointer at the bottom close that gap without disturbing the existing command reference.
