### PR TITLE
Add Dependabot config for Bundler and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    versioning-strategy: lockfile-only
+    labels:
+      - dependencies
+      - ruby
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - github-actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Dependabot config** (`.github/dependabot.yml`). Weekly bump PRs
+  for Bundler and GitHub Actions, with `open-pull-requests-limit: 3`
+  per ecosystem. `versioning-strategy: lockfile-only` on bundler, so
+  Gemfile / gemspec constraints are never auto-widened — humans
+  widen `~>` bounds intentionally. Targets `develop` so bumps flow
+  through the normal release cycle alongside feature work.
 - **`-v` / `--verbose` flag on the `cgminer_api_client` CLI.** Logs the
   JSON request and raw response to stderr, one line each, with a
   `host:port` prefix so multi-miner fan-out output stays grep-able. The

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -61,7 +61,7 @@ Indirect deps (from lockfile): `ast`, `diff-lcs`, `docile`, `json`, `language_se
 - **Matrix:** 3.2, 3.3, 3.4, 4.0 (required), and `head` (allowed to fail as an early-warning signal).
 - **Caching:** `ruby/setup-ruby@v1` with `bundler-cache: true` for gem caching.
 
-Travis CI (`.travis.yml`) and WhiteSource Bolt (`.whitesource`) were removed in 0.3.0. If SCA is wanted later, add Dependabot via `.github/dependabot.yml` — the 0.3.0 changelog flags this as the intended path.
+Travis CI (`.travis.yml`) and WhiteSource Bolt (`.whitesource`) were removed in 0.3.0; SCA is now handled by Dependabot (`.github/dependabot.yml`, see "Dependency update strategy" below).
 
 ## Ruby version support
 
@@ -80,6 +80,8 @@ Travis CI (`.travis.yml`) and WhiteSource Bolt (`.whitesource`) were removed in 
 
 ## Dependency update strategy
 
-The gem has no Dependabot or Renovate configured. Manual dep bumps happen as part of release work. Minimum version constraints in the Gemfile are intentionally set a floor-or-above (`rake >= 13.2`, `rspec >= 3.13`, etc.) so Bundler resolves recent versions without over-constraining.
+Dependency bumps arrive automatically via Dependabot (see `.github/dependabot.yml`). Weekly runs open PRs for Bundler and GitHub Actions updates, capped at 3 open PRs per ecosystem. PRs target the `develop` branch and use `versioning-strategy: lockfile-only` — Gemfile.lock moves forward automatically, but Gemfile / gemspec `~>` bounds are never auto-widened. A human widens bounds intentionally when they're ready to adopt a new major/minor line.
+
+Minimum version constraints in the Gemfile are intentionally set as a floor-or-above (`rake >= 13.2`, `rspec >= 3.13`, etc.) so Bundler resolves recent versions without over-constraining.
 
 The gem's own consumers should treat `cgminer_api_client` as a zero-transitive-footprint dep — installing it adds exactly one gem to their lockfile.


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` tracking Bundler and GitHub Actions weekly.
- `open-pull-requests-limit: 3` per ecosystem; PRs target `develop`.
- `versioning-strategy: lockfile-only` on bundler — lockfile moves automatically, gemspec/Gemfile constraints only change on human intent.
- CHANGELOG entry under `[Unreleased]`.
- `docs/dependencies.md` "Dependency update strategy" section updated — no longer claims the repo has no Dependabot.

## Test plan
- [ ] CI green on the feature branch (unchanged Ruby code, spec suite should be unaffected).
- [ ] After merge: Insights → Dependency graph → Dependabot lists `bundler` and `github-actions` as tracked ecosystems with no red parse error.
- [ ] Next weekly run opens bump PRs (if any updates are available) against `develop`, labeled `dependencies`.