### PR TITLE
Add bundle-audit to CI for Gemfile.lock CVE gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,18 @@ jobs:
 
       - name: Run tests and lint
         run: bundle exec rake
+
+  audit:
+    name: bundle-audit
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Run bundle-audit
+        run: bundle exec bundle-audit check --update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`bundle-audit` in CI** (`.github/workflows/ci.yml`). New `audit`
+  job runs `bundle exec bundle-audit check --update` on every push
+  and PR, gating merges on known CVEs in `Gemfile.lock`. Advisory
+  DB is refreshed on each run from `rubysec/ruby-advisory-db`. Also
+  available locally as `bundle exec rake audit`.
 - **Dependabot config** (`.github/dependabot.yml`). Weekly bump PRs
   for Bundler and GitHub Actions, with `open-pull-requests-limit: 3`
   per ecosystem. `versioning-strategy: lockfile-only` on bundler, so

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,11 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'rake',      '>= 13.2'
-  gem 'rspec',     '>= 3.13'
+  gem 'bundler-audit', '>= 0.9'
+  gem 'rake',          '>= 13.2'
+  gem 'rspec',         '>= 3.13'
   gem 'rubocop',       '>= 1.60'
   gem 'rubocop-rake',  '>= 0.6'
   gem 'rubocop-rspec', '>= 2.27'
-  gem 'simplecov', '>= 0.22'
+  gem 'simplecov',     '>= 0.22'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -12,3 +12,8 @@ task default: %i[spec rubocop]
 
 desc 'Alias for spec'
 task test: :spec
+
+desc 'Check Gemfile.lock against the ruby-advisory-db for known CVEs'
+task :audit do
+  sh 'bundle exec bundle-audit check --update'
+end


### PR DESCRIPTION
## Summary
- Adds `bundler-audit` to the `group :development` dev gems.
- New `audit` job in `.github/workflows/ci.yml` runs `bundle exec bundle-audit check --update` on every push and PR, gating merges on any known CVE in `Gemfile.lock`.
- `rake audit` task available locally (not in `rake default` — keeps the common dev loop fast and offline-capable).
- CHANGELOG entry under `[Unreleased]`.

Complements the Dependabot config landed in PR #4: Dependabot keeps `Gemfile.lock` moving as new gem versions drop; `bundle-audit` enforces "can't merge with a known CVE in the current lockfile."

## Test plan
- [x] `bundle exec rake audit` passes locally (1078 advisories; no vulnerabilities found).
- [x] `bundle exec rake` (spec + rubocop) still green — 226 examples, no offenses.
- [x] CI `audit` job turns green on the PR.