### PR TITLE
docs: add logging stub clarifying silent-by-design posture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`docs/logging.md`** — short stub stating that `cgminer_api_client`
+  is intentionally silent: no `Logger` module, no structured log
+  events. The library raises on failure and returns result objects
+  on success; callers (`cgminer_monitor`, `cgminer_manager`, the
+  operator CLIs) own the log call sites. Points at
+  `cgminer_monitor/docs/log_schema.md` for the cross-repo schema
+  contract and names the events (`poll.miner_failed`,
+  `poll.unexpected_error`) that surface api_client exception classes.
 - **`bundle-audit` in CI** (`.github/workflows/ci.yml`). New `audit`
   job runs `bundle exec bundle-audit check --update` on every push
   and PR, gating merges on known CVEs in `Gemfile.lock`. Advisory

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,21 @@
+# Logging
+
+`cgminer_api_client` is **silent by design.** It has no `Logger` module and emits no structured log events. On failure it raises (`CgminerApiClient::ConnectionError`, `CgminerApiClient::SocketReadTimeout`, `CgminerApiClient::ProtocolError`, etc.); on success it returns `CgminerApiClient::MinerResult` or `CgminerApiClient::PoolResult` instances.
+
+Callers — `cgminer_monitor`'s poll loop, `cgminer_manager`'s fleet commander, the `bin/cgminer_api_client` CLI — own the log call sites and decide what's worth emitting. This keeps the library dependency-free of any logging backend and lets each consumer pick its own verbosity / destination / format.
+
+The CLI has a `-v`/`--verbose` flag that prints each request and response to stderr with a direction prefix + `host:port`. This is operator-facing diagnostic output, not a structured-log contract — the lines are not JSON and are not intended to be parsed. Use it to debug a specific miner interactively; don't pipe it into an aggregator.
+
+## How callers log api_client outcomes
+
+Both sibling gems follow the structured-log contract documented in `cgminer_monitor`:
+
+→ **[cgminer_monitor/docs/log_schema.md](https://github.com/jramos/cgminer_monitor/blob/develop/docs/log_schema.md)**
+
+The events of interest for api_client-outcome tracing:
+
+- `poll.miner_failed` (cgminer_monitor) — emitted when `CgminerApiClient::MinerPool#query` raises for a specific miner. Carries `miner`, `command`, `error`.
+- `poll.unexpected_error` (cgminer_monitor) — emitted when the poll loop itself catches something unexpected. Carries `error`, `message`, `backtrace`.
+- `monitor.call` / `monitor.call.failed` (cgminer_manager) — *manager's* outbound HTTP calls to monitor, not api_client calls. Separate path.
+
+The exception class names that surface in those events (`error:` key) are api_client's public error hierarchy in `lib/cgminer_api_client/errors.rb`.


### PR DESCRIPTION
## Summary

- Adds `docs/logging.md` (~25 lines) stating the design intent explicitly: `cgminer_api_client` has no `Logger` module and emits no structured log events. It raises on failure and returns result objects on success; callers own log emission.
- Notes the CLI's `-v`/`--verbose` flag is operator-facing stderr diagnostic output, not a structured-log contract (wire lines aren't JSON and shouldn't be piped to an aggregator).
- Links to `cgminer_monitor/docs/log_schema.md` as the cross-repo source of truth for the structured-log schema, and names the two monitor-side events (`poll.miner_failed`, `poll.unexpected_error`) whose `error:` key surfaces api_client's exception-class hierarchy.

## Scope

Part of the cross-repo structured-log-schema rollout. Companion PRs:
- `cgminer_monitor` PR #9 (canonical `docs/log_schema.md` + `server.start` shape flatten)
- `cgminer_manager` PR #24 (stub + `elapsed_ms`/`render_ms` → `duration_ms`)

Land cgminer_monitor first so the cross-repo link resolves immediately.

Pure docs — no Ruby API change, no version bump.

## Test plan

- [x] `bundle exec rake` — 226 examples, 0 failures; rubocop clean
- [ ] Eyeball `docs/logging.md` on the GitHub PR diff view — cross-repo link resolves after cgminer_monitor PR #9 merges