### PR TITLE
Cut v0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ A pure-Ruby client for the [cgminer](https://github.com/ckolivas/cgminer) JSON-o
 ├── bin/cgminer_api_client        # CLI (packaged in gem)
 ├── lib/cgminer_api_client.rb     # Entry point + module-level config (packaged)
 ├── lib/cgminer_api_client/
-│   ├── errors.rb                 # Error < StandardError, ConnectionError, TimeoutError, ApiError (+ ApiError#cgminer_code, #code)
+│   ├── errors.rb                 # Error < StandardError, ConnectionError, TimeoutError, ApiError (+ #cgminer_code, #code), AccessDeniedError
 │   ├── miner.rb                  # Single-host client
 │   ├── miner/commands.rb         # ReadOnly + Privileged.{Asc,Pga,Pool,System}
 │   ├── miner_pool.rb             # Parallel fan-out across a pool
@@ -113,8 +113,9 @@ Lib ─┼──> MinerPool ──(parallel threads)──> Miner ──> socket
 
 ### Error handling
 
-- New errors should subclass one of the existing four (`Error`, `ConnectionError`, `TimeoutError`, `ApiError`) — don't add a sibling unless you have a real reason. The hierarchy is deliberate: `ConnectionError` = "couldn't reach the miner", `ApiError` = "miner answered and rejected". Keep those semantics intact.
-- **`ApiError` carries structured fields, not just a message.** `#cgminer_code` is the integer Code from cgminer's STATUS hash (or nil if the error wasn't sourced from a wire response — e.g., the `access_denied?` local guard). `#code` is a symbolic Ruby tag derived from that integer via `ApiError::CGMINER_CODES`, falling back to `:unknown`. Callers dispatch on `e.code`, never on `e.message =~ /access denied/i`. The map is intentionally conservative — only codes the test suite or production has actually observed against real cgminer 4.11.1 fixtures (`14 → :invalid_command`, `45 → :access_denied`). When you find a code worth dispatching on, add a row.
+- The hierarchy is deliberate: `ConnectionError` = "couldn't reach the miner", `ApiError` = "miner answered and rejected". Keep those semantics intact. `AccessDeniedError < ApiError` covers the most commonly dispatched-on case (cgminer Code 45 + the `access_denied?` local guard); add another `ApiError` subclass only when a code earns enough dispatch-site interest to outweigh the asymmetry of having more subclasses for some codes than others.
+- **`ApiError` carries structured fields, not just a message.** `#cgminer_code` is the integer Code from cgminer's STATUS hash (or nil if the wire integer was discarded — e.g., the `access_denied?` local guard's call to `privileged` hits the wire, but the rescue inside `privileged` drops the integer before re-raising). `#code` is a symbolic Ruby tag derived from that integer via `ApiError::CGMINER_CODES`, falling back to `:unknown`. **Prefer `e.code` for dispatch over `e.cgminer_code`** — `cgminer_code` can be nil even when the symbolic tag is set. Callers dispatch on `e.code`, never on `e.message =~ /access denied/i`. The map is intentionally conservative — only wire-observed codes (`14 → :invalid_command`, `45 → :access_denied`); add a row when you find a code worth dispatching on.
+- `ApiError.for_status(c, msg)` is the wire-side factory used by `Miner#check_status`. It picks the right subclass (`AccessDeniedError` for Code 45, `ApiError` otherwise) and coerces a non-numeric Code to nil so `:unknown` falls through cleanly. Don't call it from non-wire paths — those raise the right class directly.
 - Rescue narrowly. `rescue SocketError, SystemCallError, CgminerApiClient::TimeoutError` in `Miner#available?` is the pattern — bugs like `ArgumentError` should propagate, not be silently swallowed.
 - `MinerPool#query` worker threads use `rescue StandardError => e` deliberately — they capture everything into a `MinerResult.failure`. One bad miner must not take down the whole pool query.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-25
+
 ### Added
 - **`CgminerApiClient::AccessDeniedError`**, a subclass of `ApiError`
   for the most commonly dispatched-on case (cgminer Code 45 + the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`CgminerApiClient::AccessDeniedError`**, a subclass of `ApiError`
+  for the most commonly dispatched-on case (cgminer Code 45 + the
+  `access_denied?` local guard). Inherits from `ApiError` so existing
+  `rescue ApiError` clauses still catch it; callers wanting finer
+  dispatch use `rescue AccessDeniedError`. Constructor pins
+  `code: :access_denied` so the symbolic tag is consistent. The
+  wire-side `Miner#check_status` delegates to a new factory
+  `ApiError.for_status(c, msg)` that picks the right subclass
+  based on the integer Code.
 - **Structured error codes on `CgminerApiClient::ApiError`.** Two new
   reader methods alongside the existing `#message`:
   `#cgminer_code` (the integer Code from cgminer's STATUS hash —
-  e.g., `45` for access denied — or `nil` for errors raised before
-  any wire interaction) and `#code` (a symbolic tag derived from
-  the integer via `ApiError::CGMINER_CODES`, falling back to
-  `:unknown` for codes not in the map). Callers can now
-  `case e.code; when :access_denied; ...` instead of parsing
-  English error strings. The map is intentionally conservative —
-  `14 → :invalid_command`, `45 → :access_denied`, the two codes
-  the test suite has observed against real cgminer 4.11.1 fixtures.
+  e.g., `45` for access denied — or `nil` if the wire integer was
+  discarded, as happens when the `access_denied?` local guard's
+  call to `privileged` hits the wire and the rescue inside
+  `privileged` drops the integer before re-raising) and `#code`
+  (a symbolic tag derived from the integer via
+  `ApiError::CGMINER_CODES`, falling back to `:unknown` for codes
+  not in the map). Callers can now `case e.code; when :access_denied`
+  instead of parsing English error strings. **Prefer `e.code` for
+  dispatch over `e.cgminer_code`** — `cgminer_code` can be nil even
+  when the symbolic tag is set. The map is intentionally
+  conservative — `14 → :invalid_command`, `45 → :access_denied`,
+  the codes observed against real cgminer wire fixtures.
   Backward-compatible: `raise ApiError, "msg"` still works and
-  `e.message` is unchanged. `Miner#check_status` now passes
-  `cgminer_code:` through verbatim from the wire response;
-  `access_denied?` (the local pre-wire guard) passes
-  `code: :access_denied` explicitly so the symbol matches a
-  real wire-side Code 45 regardless of which path raised.
+  `e.message` is unchanged.
+
+### Changed
+- `ApiError` constructor now validates `cgminer_code:` is `Integer`
+  or `nil` and `code:` is `Symbol`, `String`, or `nil`. Bad input
+  raises `ArgumentError` with a clear message instead of silently
+  producing `code: :unknown` (string `cgminer_code`) or
+  `NoMethodError` deep in the constructor (`code: 42`). Wire-side
+  callers go through `ApiError.for_status` which coerces a
+  non-numeric Code to `nil` so dispatch falls through to `:unknown`.
 - **`docs/logging.md`** — short stub stating that `cgminer_api_client`
   is intentionally silent: no `Logger` module, no structured log
   events. The library raises on failure and returns result objects

--- a/lib/cgminer_api_client/errors.rb
+++ b/lib/cgminer_api_client/errors.rb
@@ -58,14 +58,19 @@ module CgminerApiClient
     end
 
     def initialize(message = nil, cgminer_code: nil, code: nil)
-      # Fail loud at the library boundary on bad input. Without this guard,
-      # cgminer_code: "45" or 45.0 silently produces code: :unknown
-      # because CGMINER_CODES uses integer keys — every dispatch site
-      # would break with no signal. Wire-side callers that want best-effort
-      # coercion should pass Integer(c, exception: false) themselves.
+      # Fail loud at the library boundary on bad input. Without these
+      # guards, cgminer_code: "45" or 45.0 silently produces code:
+      # :unknown (CGMINER_CODES uses integer keys), and code: 42 raises
+      # NoMethodError on .to_sym deep in the constructor — both
+      # opaque failure modes. Wire-side callers that want best-effort
+      # Integer coercion go through ApiError.for_status.
       unless cgminer_code.nil? || cgminer_code.is_a?(Integer)
         raise ArgumentError,
               "cgminer_code must be Integer or nil, got #{cgminer_code.class}: #{cgminer_code.inspect}"
+      end
+      unless code.nil? || code.is_a?(Symbol) || code.is_a?(String)
+        raise ArgumentError,
+              "code must be Symbol, String, or nil, got #{code.class}: #{code.inspect}"
       end
 
       super(message)

--- a/lib/cgminer_api_client/errors.rb
+++ b/lib/cgminer_api_client/errors.rb
@@ -18,31 +18,24 @@ module CgminerApiClient
 
   # Raised when the miner returned a response whose STATUS field
   # indicates an error (cgminer status code 'E' or 'F'). The message
-  # contains the cgminer code and message verbatim. Two structured
-  # fields are also attached so callers can dispatch without parsing
-  # English error strings:
+  # contains the cgminer code and message verbatim.
   #
-  #   #cgminer_code -- the integer Code from cgminer's STATUS hash
-  #                    (e.g., 45 for access denied), or nil if the
-  #                    error wasn't sourced from a cgminer response
-  #                    (e.g., the gem's own access_denied? guard
-  #                    raises before any wire interaction).
-  #   #code         -- a symbolic Ruby tag derived from cgminer_code
-  #                    via CGMINER_CODES, or :unknown if the integer
-  #                    isn't in the map. Callers can also pass an
-  #                    explicit code: kwarg when raising from a path
-  #                    that doesn't carry a cgminer integer.
+  # Carries two structured fields for dispatch: callers `case e.code`
+  # instead of parsing English messages. The integer (#cgminer_code)
+  # is preserved verbatim from cgminer; the symbol (#code) is
+  # best-effort — cgminer's MSG enum names are stable but the
+  # integers occasionally shift between firmware versions, so add a
+  # row to CGMINER_CODES when you find a wire-observed integer worth
+  # dispatching on.
   #
-  # cgminer's MSG enum names are stable but the integers occasionally
-  # shift between firmware versions, so the integer is preserved
-  # verbatim and the symbol is best-effort. Add a row to CGMINER_CODES
-  # when you find a code worth dispatching on; the map is intentionally
-  # conservative (only codes the test suite or production has actually
-  # observed against real cgminer traffic).
+  # Prefer #code for dispatch over #cgminer_code: paths that raise
+  # without a wire integer (the access_denied? local guard's call
+  # to #privileged hits the wire, but the rescue inside #privileged
+  # drops the integer) leave #cgminer_code nil while still setting
+  # #code consistently.
   #
-  # Backward compatibility: ApiError still accepts a single positional
-  # message argument, so `raise ApiError, "msg"` keeps working. Existing
-  # rescues that read .message see the same string they always did.
+  # Backward compatibility: `raise ApiError, "msg"` keeps working
+  # and #message is unchanged at every emission site.
   class ApiError < Error
     CGMINER_CODES = {
       14 => :invalid_command,
@@ -50,6 +43,19 @@ module CgminerApiClient
     }.freeze
 
     attr_reader :cgminer_code, :code
+
+    # Factory used at the wire-side emission point in Miner#check_status.
+    # Picks AccessDeniedError when the cgminer integer maps to
+    # :access_denied so callers can `rescue AccessDeniedError` for
+    # the most commonly dispatched-on case; falls back to ApiError
+    # for everything else. Wire boundary stays best-effort: a
+    # non-numeric Code coerces to nil and the symbolic tag becomes
+    # :unknown rather than raising mid-poll.
+    def self.for_status(status_code, message)
+      cgminer_code = Integer(status_code, exception: false)
+      klass = CGMINER_CODES[cgminer_code] == :access_denied ? AccessDeniedError : ApiError
+      klass.new("#{status_code}: #{message}", cgminer_code: cgminer_code)
+    end
 
     def initialize(message = nil, cgminer_code: nil, code: nil)
       # Fail loud at the library boundary on bad input. Without this guard,
@@ -65,6 +71,19 @@ module CgminerApiClient
       super(message)
       @cgminer_code = cgminer_code
       @code = (code || CGMINER_CODES[cgminer_code] || :unknown).to_sym
+    end
+  end
+
+  # Specific subclass for cgminer's "access denied" response (STATUS=E
+  # Code 45) and the gem's own #access_denied? local guard. Inherits
+  # from ApiError so existing `rescue ApiError` clauses still catch
+  # it; callers wanting finer dispatch use `rescue AccessDeniedError`
+  # instead of `case e.code; when :access_denied`. Constructor pins
+  # code: :access_denied so the symbolic tag is consistent regardless
+  # of which call site raised.
+  class AccessDeniedError < ApiError
+    def initialize(message = nil, cgminer_code: nil)
+      super(message, cgminer_code: cgminer_code, code: :access_denied)
     end
   end
 end

--- a/lib/cgminer_api_client/miner.rb
+++ b/lib/cgminer_api_client/miner.rb
@@ -149,14 +149,12 @@ module CgminerApiClient
       msg    = status['Msg']
 
       # cgminer STATUS codes: S=Success (silent), I=Info, W=Warning,
-      # E=Error, F=Fatal. Errors and Fatals raise ApiError so callers
-      # can distinguish them from ConnectionError (transport-level
-      # failures). The wire boundary stays best-effort: if a future
-      # firmware ever emits Code as a JSON string instead of an integer,
-      # Integer(...) coerces it; if it's non-numeric, falls through to
-      # nil and ApiError#code becomes :unknown rather than raising
-      # ArgumentError mid-poll. The library boundary stays strict —
-      # see ApiError#initialize.
+      # E=Error, F=Fatal. Errors and Fatals raise via ApiError.for_status
+      # which picks AccessDeniedError for Code 45 (so callers can
+      # `rescue AccessDeniedError`) and falls back to ApiError otherwise.
+      # The wire boundary stays best-effort — non-numeric Codes coerce
+      # to nil and the symbolic tag becomes :unknown rather than
+      # raising mid-poll.
       case sc
       when 'S'
         # no-op: success needs no notification
@@ -165,7 +163,7 @@ module CgminerApiClient
       when 'W'
         puts "Warning from API [#{c}]: #{msg}"
       else
-        raise ApiError.new("#{c}: #{msg}", cgminer_code: Integer(c, exception: false))
+        raise ApiError.for_status(c, msg)
       end
     end
 

--- a/lib/cgminer_api_client/miner/commands.rb
+++ b/lib/cgminer_api_client/miner/commands.rb
@@ -188,13 +188,13 @@ module CgminerApiClient
         def access_denied?
           # privileged calls query(:privileged), so the wire IS hit; if
           # the miner answers with STATUS=E Code 45, check_status raises
-          # and privileged rescues + returns false, dropping the cgminer
-          # integer in the rescue. Re-attach the symbolic code explicitly
-          # so callers can't tell which call path raised — dispatch on
-          # e.code works identically for "real wire denied" and
-          # "guard-locally denied". e.cgminer_code stays nil here because
-          # it was discarded by privileged's rescue.
-          raise CgminerApiClient::ApiError.new('access denied', code: :access_denied) unless privileged
+          # AccessDeniedError and privileged rescues + returns false,
+          # dropping the cgminer integer in the rescue. Re-raise the
+          # specific subclass so callers can't tell which call path
+          # raised — `rescue AccessDeniedError` works identically for
+          # "real wire denied" and "guard-locally denied". cgminer_code
+          # stays nil here because it was discarded by privileged's rescue.
+          raise CgminerApiClient::AccessDeniedError, 'access denied' unless privileged
 
           false
         end

--- a/lib/cgminer_api_client/version.rb
+++ b/lib/cgminer_api_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CgminerApiClient
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/spec/cgminer_api_client/access_denied_error_spec.rb
+++ b/spec/cgminer_api_client/access_denied_error_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe CgminerApiClient::AccessDeniedError do
+  describe 'class hierarchy' do
+    it 'inherits from ApiError so existing `rescue ApiError` clauses still catch it' do
+      expect(described_class.ancestors).to include(CgminerApiClient::ApiError)
+    end
+
+    it 'inherits from Error so `rescue CgminerApiClient::Error` still catches it' do
+      expect(described_class.ancestors).to include(CgminerApiClient::Error)
+    end
+
+    it 'is a StandardError descendant' do
+      expect(described_class.ancestors).to include(StandardError)
+    end
+  end
+
+  describe '#initialize' do
+    context 'with default args (the access_denied? local-guard form)' do
+      let(:e) { described_class.new('access denied') }
+
+      it 'preserves the message' do
+        expect(e.message).to eq('access denied')
+      end
+
+      it 'pins code to :access_denied regardless of constructor input' do
+        expect(e.code).to eq(:access_denied)
+      end
+
+      it 'leaves cgminer_code nil when not supplied' do
+        expect(e.cgminer_code).to be_nil
+      end
+    end
+
+    context 'with cgminer_code (the wire-side Code 45 form)' do
+      let(:e) { described_class.new('45: Access denied', cgminer_code: 45) }
+
+      it 'preserves the cgminer integer' do
+        expect(e.cgminer_code).to eq(45)
+      end
+
+      it 'still pins code to :access_denied' do
+        expect(e.code).to eq(:access_denied)
+      end
+    end
+  end
+
+  describe 'rescue dispatch' do
+    it 'is rescued by `rescue AccessDeniedError`' do
+      expect { raise described_class, 'denied' }
+        .to raise_error(described_class)
+    end
+
+    it 'is rescued by `rescue ApiError` (subclass dispatch)' do
+      expect { raise described_class, 'denied' }
+        .to raise_error(CgminerApiClient::ApiError)
+    end
+
+    it 'is rescued by `rescue CgminerApiClient::Error` (base dispatch)' do
+      expect { raise described_class, 'denied' }
+        .to raise_error(CgminerApiClient::Error)
+    end
+  end
+end

--- a/spec/cgminer_api_client/api_error_spec.rb
+++ b/spec/cgminer_api_client/api_error_spec.rb
@@ -126,6 +126,48 @@ describe CgminerApiClient::ApiError do
       end
     end
 
+    context 'with non-Symbol-or-String code (library-boundary input validation)' do
+      # Without this guard, code: 42 raises NoMethodError on .to_sym
+      # deep in the constructor — opaque to the caller. Fail loudly
+      # with the right error class instead.
+      it 'raises ArgumentError on an Integer' do
+        expect { described_class.new('msg', code: 42) }
+          .to raise_error(ArgumentError, /code must be Symbol, String, or nil/)
+      end
+
+      it 'raises ArgumentError on a Hash' do
+        expect { described_class.new('msg', code: { foo: 1 }) }
+          .to raise_error(ArgumentError, /code must be Symbol, String, or nil/)
+      end
+
+      it 'raises ArgumentError on an Array' do
+        expect { described_class.new('msg', code: [:foo]) }
+          .to raise_error(ArgumentError, /code must be Symbol, String, or nil/)
+      end
+
+      it 'raises ArgumentError on false (rather than silently treating it as nil)' do
+        # false || x evaluates to x in Ruby, so without the guard
+        # code: false would silently bypass to map lookup. Loud is right.
+        expect { described_class.new('msg', code: false) }
+          .to raise_error(ArgumentError, /code must be Symbol, String, or nil/)
+      end
+
+      it 'still accepts a Symbol (regression guard)' do
+        expect { described_class.new('msg', code: :access_denied) }
+          .not_to raise_error
+      end
+
+      it 'still accepts a String (regression guard for to_sym coercion)' do
+        expect { described_class.new('msg', code: 'access_denied') }
+          .not_to raise_error
+      end
+
+      it 'still accepts nil (regression guard for the default path)' do
+        expect { described_class.new('msg', code: nil) }
+          .not_to raise_error
+      end
+    end
+
     context 'with non-Integer cgminer_code (library-boundary input validation)' do
       # The constructor is the library's strict boundary. Without this
       # guard, cgminer_code: "45" silently produces code: :unknown

--- a/spec/cgminer_api_client/api_error_spec.rb
+++ b/spec/cgminer_api_client/api_error_spec.rb
@@ -154,6 +154,47 @@ describe CgminerApiClient::ApiError do
     end
   end
 
+  describe '.for_status (factory used by Miner#check_status)' do
+    it 'returns AccessDeniedError when the integer maps to :access_denied' do
+      e = described_class.for_status(45, 'Access denied')
+      expect(e).to be_a(CgminerApiClient::AccessDeniedError)
+      expect(e.cgminer_code).to eq(45)
+      expect(e.code).to eq(:access_denied)
+      expect(e.message).to eq('45: Access denied')
+    end
+
+    it 'returns plain ApiError for mapped non-access-denied codes' do
+      e = described_class.for_status(14, 'Invalid command')
+      expect(e).to be_an_instance_of(described_class)
+      expect(e).not_to be_a(CgminerApiClient::AccessDeniedError)
+      expect(e.cgminer_code).to eq(14)
+      expect(e.code).to eq(:invalid_command)
+    end
+
+    it 'returns plain ApiError with :unknown for unmapped codes' do
+      e = described_class.for_status(999, 'Strange')
+      expect(e).to be_an_instance_of(described_class)
+      expect(e.cgminer_code).to eq(999)
+      expect(e.code).to eq(:unknown)
+    end
+
+    it 'coerces a String Code to Integer (best-effort wire boundary)' do
+      # cgminer normally emits Code as integer, but defending against
+      # firmware that ever returns "45" as JSON string keeps dispatch
+      # working.
+      e = described_class.for_status('45', 'Access denied')
+      expect(e).to be_a(CgminerApiClient::AccessDeniedError)
+      expect(e.cgminer_code).to eq(45)
+    end
+
+    it 'falls through to :unknown when the Code is non-numeric' do
+      e = described_class.for_status('not-a-number', 'Weird')
+      expect(e).to be_an_instance_of(described_class)
+      expect(e.cgminer_code).to be_nil
+      expect(e.code).to eq(:unknown)
+    end
+  end
+
   describe 'compatibility with raise/rescue' do
     it 'works with raise(class, message) — the legacy two-arg form' do
       expect { raise described_class, 'boom' }

--- a/spec/cgminer_api_client/miner/commands_spec.rb
+++ b/spec/cgminer_api_client/miner/commands_spec.rb
@@ -194,6 +194,11 @@ describe CgminerApiClient::Miner::Commands do
           end.to raise_error(CgminerApiClient::ApiError, 'access denied')
         end
 
+        it 'raises the AccessDeniedError subclass specifically' do
+          expect { instance.send(:access_denied?) }
+            .to raise_error(CgminerApiClient::AccessDeniedError, 'access denied')
+        end
+
         it 'attaches code: :access_denied so callers can dispatch without parsing the message' do
           # privileged is stubbed to return false here, so access_denied?
           # re-raises with the symbolic code only — cgminer_code stays

--- a/spec/cgminer_api_client/miner_spec.rb
+++ b/spec/cgminer_api_client/miner_spec.rb
@@ -504,6 +504,16 @@ describe CgminerApiClient::Miner do
           mock_response['STATUS'] = [{ 'STATUS' => 'F', 'Code' => 23, 'Msg' => 'Bad command' }]
         end
 
+        # Forward-rot guard: the :unknown-fallback assertion below relies
+        # on 23 being absent from the map. A future PR mapping 23 to a
+        # symbol would silently exercise the mapped path while still
+        # claiming to test :unknown — this precondition trips loudly so
+        # the test is updated alongside the map change (pick a different
+        # unmapped integer here when 23 gets mapped).
+        it 'precondition: 23 is unmapped in CGMINER_CODES' do
+          expect(CgminerApiClient::ApiError::CGMINER_CODES).not_to have_key(23)
+        end
+
         it 'raises ApiError' do
           expect do
             instance.send(:check_status, mock_response)

--- a/spec/cgminer_api_client/miner_spec.rb
+++ b/spec/cgminer_api_client/miner_spec.rb
@@ -492,6 +492,11 @@ describe CgminerApiClient::Miner do
               expect(e.code).to eq(:access_denied)
             end
         end
+
+        it 'raises the AccessDeniedError subclass so callers can rescue it specifically' do
+          expect { instance.send(:check_status, mock_response) }
+            .to raise_error(CgminerApiClient::AccessDeniedError)
+        end
       end
 
       context 'with fatal status' do

--- a/spec/integration/miner_integration_spec.rb
+++ b/spec/integration/miner_integration_spec.rb
@@ -130,7 +130,7 @@ describe 'Miner integration with a fake cgminer server' do
       )
       CgminerTestSupport::FakeCgminer.with(responses: responses) do |port|
         expect { miner_at(port).query(:privileged) }
-          .to raise_error(CgminerApiClient::ApiError) do |e|
+          .to raise_error(CgminerApiClient::AccessDeniedError) do |e|
             expect(e.cgminer_code).to eq(45)
             expect(e.code).to eq(:access_denied)
           end


### PR DESCRIPTION
Release the [Unreleased] work since v0.3.0 so cgminer_manager v1.6.0 can depend on the on_wire: kwarg via the closure-based wiring pattern.

## Highlights

- **on_wire: kwarg** on Miner#initialize / MinerPool#initialize for wire-level telemetry hooks
- **-v / --verbose CLI flag** with addpool/setconfig/ascset/pgaset password redaction
- **Structured ApiError**: #cgminer_code (Integer) + #code (Symbol) + CGMINER_CODES map (14, 45)
- **AccessDeniedError subclass** + ApiError.for_status factory
- **Constructor input validation**: ArgumentError on non-Integer cgminer_code:, non-Symbol/non-String code:
- **MinerPool#load_miners!** raises CgminerApiClient::Error (was RuntimeError) on missing miners.yml
- **docs/logging.md** silent-by-design stub
- **bundle-audit** + **Dependabot** in CI
- **cgminer_test_support extraction** (FakeCgminer + Fixtures moved to shared gem)

Required by cgminer_manager v1.6.0 — the trace-id propagation work threads request_id into per-request Miner instances via on_wire:.

## Test plan

- [x] bundle exec rake clean (25 files, no rubocop offenses)
- [x] 284 examples, 0 failures
- [x] All v0.3.0 → v0.4.0 changes already merged through individual PRs (#5 through #10); this PR just cuts the release tag